### PR TITLE
Fixes for previous year agenda handling

### DIFF
--- a/website/app/lib/config-types.ts
+++ b/website/app/lib/config-types.ts
@@ -2,12 +2,12 @@ import type { DateTime } from 'luxon'
 
 export type Year = `${number}${number}${number}${number}`
 
-export type ConferenceConfigYear =
-    | ConferenceYear
-    | {
-          year: Year
-          cancelledMessage: string
-      }
+export type CancelledConferenceYear = {
+    year: Year
+    cancelledMessage: string
+}
+
+export type ConferenceConfigYear = ConferenceYear | CancelledConferenceYear
 
 /**
  * Conference configuration which doesn't necessarily change year on year

--- a/website/app/lib/get-year-config.tsx
+++ b/website/app/lib/get-year-config.tsx
@@ -9,7 +9,7 @@ export function getYearConfig(
     year: Year,
     conference: ConferenceImportantInformation,
     dateTimeProvider: DateTimeProvider,
-    allowCancelled: boolean = false,
+    allowCancelled = false,
 ) {
     const yearConfigLookup = (conferenceConfig.conferences as Record<Year, ConferenceConfigYear | undefined>)[year]
     const cancelled = yearConfigLookup && 'cancelledMessage' in yearConfigLookup


### PR DESCRIPTION
Updated agenda layout to better handle missing conference/schedule info, and display the cancelledMessage if the conference did not go ahead.
Still TODO: actually restore the 2018 and 2019 agendas.

---

Agenda 2019, currently:
![image](https://github.com/user-attachments/assets/dd34fa58-6a23-4360-be65-d0ff05774ec2)

Agenda 2019, with this PR:
![image](https://github.com/user-attachments/assets/7ca3c9f7-9301-465a-bfb6-40fd5549358e)

Agenda 2020, currently: [redirects to base /agenda route]

Agenda 2020, with this PR:
![image](https://github.com/user-attachments/assets/51ba81b9-3a73-4bf8-a635-629576fabd6a)

---

Please feel free to make any changes necessary, especially with text content, font size etc.