### PR TITLE
Fix agenda planning loader: all-sessions endpoint and run's own year

### DIFF
--- a/core/website/app/routes/admin.voting_.agenda.$runId.tsx
+++ b/core/website/app/routes/admin.voting_.agenda.$runId.tsx
@@ -125,27 +125,14 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     await requireAdmin(request, context)
 
     const { runId } = params
-    const conferenceState = getConferenceState(context)
-    const year = conferenceState.conference.year
-
-    const yearConfig = getYearConfig(year, getConfig(context))
-
-    if (yearConfig.kind === 'cancelled') {
-        throw new Response(JSON.stringify({ message: 'No sessionize endpoint for year' }), { status: 404 })
-    }
-
-    if (yearConfig.sessions?.kind !== 'sessionize' || !yearConfig.sessions.sessionizeEndpoint) {
-        throw new Response(JSON.stringify({ message: 'No sessionize endpoint for year' }), { status: 404 })
-    }
-    const sessionizeEndpoint = yearConfig.sessions.sessionizeEndpoint
-    const underrepresentedGroupsQuestionId = yearConfig.sessions.underrepresentedGroupsQuestionId
-
     const voting = getServices(context).voting
 
+    let runYear: string | null = null
     let runDetails: { startedAt: string; completedAt?: string; status: string } | null = null
     try {
         const runEntity = await voting.getValidationRunById(runId)
         if (runEntity) {
+            runYear = runEntity.year
             runDetails = {
                 startedAt: runEntity.startedAt,
                 completedAt: runEntity.completedAt,
@@ -155,6 +142,26 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     } catch (error: any) {
         console.error('Error getting run details:', error)
     }
+
+    // Use the run's own year so a past run still enriches against the
+    // Sessionize event it was voted on, not the current conference's.
+    const year = runYear ?? getConferenceState(context).conference.year
+
+    const yearConfig = getYearConfig(year, getConfig(context))
+
+    if (yearConfig.kind === 'cancelled') {
+        throw new Response(JSON.stringify({ message: 'No sessionize endpoint for year' }), { status: 404 })
+    }
+
+    // Validation runs cover every submitted talk, so enrich from the
+    // all-sessions endpoint — the public sessionizeEndpoint only lists
+    // accepted talks (and may not exist yet while the agenda is planned),
+    // which would wrongly auto-default the rest to Declined.
+    if (yearConfig.sessions?.kind !== 'sessionize' || !yearConfig.sessions.allSessionsEndpoint) {
+        throw new Response(JSON.stringify({ message: 'No sessionize endpoint for year' }), { status: 404 })
+    }
+    const sessionizeEndpoint = yearConfig.sessions.allSessionsEndpoint
+    const underrepresentedGroupsQuestionId = yearConfig.sessions.underrepresentedGroupsQuestionId
 
     const talkResults = await voting.getTalkResults(runId)
 


### PR DESCRIPTION
Follow-up to #117, fixing two issues found in review of the agenda planning page loader:

1. **Use `allSessionsEndpoint` instead of the public `sessionizeEndpoint`** — matching the stats route. Validation runs cover every submitted talk, but the public endpoint only lists accepted talks and is `undefined` for 2026 in production config, so the page would 404 (or, once the public feed exists, wrongly auto-default every not-yet-accepted talk to Declined during planning). Local dev masked this because `.dev.vars` points `SESSIONIZE_2026_SESSIONS` at the all-sessions URL.

2. **Resolve the year from the validation run itself** (`runEntity.year ??` current conference year, same as the stats route) instead of always using the current conference year — so opening a 2026 run's agenda after the site rolls to 2027 still enriches against the 2026 Sessionize event rather than marking every talk "removed from Sessionize"/Declined.

## Test plan

- [x] `pnpm nx typecheck website` clean
- [x] `pnpm nx lint website` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXoHmHGh4qtqKoJQz4Cn4Z