### PR TITLE
Speaker portal: dietary requirements on dinner RSVP; Sessionize data read live

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,6 +33,9 @@ jobs:
             - name: Generate types (PandaCSS + React Router)
               run: pnpm run setup
 
+            - name: Validate D1 migrations apply cleanly
+              run: pnpm nx d1-migrate-local website
+
             - name: Type Check
               run: pnpm tsc -b
 

--- a/core/website/app/components/speaker-dinner-modal.tsx
+++ b/core/website/app/components/speaker-dinner-modal.tsx
@@ -12,8 +12,32 @@ const radioRowClass = css({
     color: 'admin.800',
 })
 
+const inputClass = css({
+    mt: '1',
+    w: 'full',
+    px: '3',
+    py: '2',
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: 'admin.400',
+    borderRadius: 'md',
+    fontSize: 'sm',
+    bg: 'white',
+    color: 'admin.900',
+    _placeholder: { color: 'admin.400' },
+    _focus: { outline: 'none', borderColor: 'indigo.7', boxShadow: 'focus-ring' },
+})
+
+const fieldLabelClass = css({
+    display: 'block',
+    fontSize: 'sm',
+    fontWeight: 'medium',
+    color: 'admin.700',
+})
+
 /**
- * "RSVP for the speaker dinner" modal — Yes/No/Maybe, submits to
+ * "RSVP for the speaker dinner" modal — Yes/No/Maybe plus dietary
+ * requirements (only relevant if they're attending), submits to
  * `rsvp-dinner`. Shows an "add to calendar" link once answered Yes or Maybe.
  */
 export function SpeakerDinnerModal({
@@ -23,6 +47,7 @@ export function SpeakerDinnerModal({
     dateLabel,
     calendarUrl,
     currentResponse,
+    currentDietaryRequirements,
     justResponded,
 }: {
     open: boolean
@@ -31,6 +56,7 @@ export function SpeakerDinnerModal({
     dateLabel: string
     calendarUrl?: string
     currentResponse?: YesNoMaybe
+    currentDietaryRequirements?: string
     justResponded: boolean
 }) {
     const navigation = useNavigation()
@@ -64,6 +90,20 @@ export function SpeakerDinnerModal({
                         </label>
                     ))}
                 </Flex>
+
+                <Box mb="5">
+                    <label htmlFor={`dietary-${sessionizeId}`} className={fieldLabelClass}>
+                        Dietary requirements
+                    </label>
+                    <input
+                        id={`dietary-${sessionizeId}`}
+                        name="dietaryRequirements"
+                        type="text"
+                        defaultValue={currentDietaryRequirements ?? ''}
+                        className={inputClass}
+                    />
+                </Box>
+
                 <Flex justify="flex-end">
                     <styled.button
                         type="submit"

--- a/core/website/app/components/speaker-profile-form.tsx
+++ b/core/website/app/components/speaker-profile-form.tsx
@@ -133,19 +133,6 @@ export function SpeakerProfileForm({
                 )}
             </Box>
 
-            <Box mb="5">
-                <label htmlFor={`dietary-${sessionizeId}`} className={fieldLabelClass}>
-                    Dietary requirements
-                </label>
-                <input
-                    id={`dietary-${sessionizeId}`}
-                    name={`dietaryRequirements-${sessionizeId}`}
-                    type="text"
-                    defaultValue={profile?.dietaryRequirements ?? ''}
-                    className={inputClass}
-                />
-            </Box>
-
             <Box mb="6">
                 <label htmlFor={`meetExperts-${sessionizeId}`} className={fieldLabelClass}>
                     Would you be interested in being a part of our Meet the Experts sessions?

--- a/core/website/app/lib/services/cloudflare/build-services.server.ts
+++ b/core/website/app/lib/services/cloudflare/build-services.server.ts
@@ -32,7 +32,7 @@ export function buildCloudflareServices(config: AppConfig, env: CloudflareEnv): 
         : createConsoleEmailService()
 
     const sponsors = createD1SponsorsStore(db)
-    const speakers = createD1SpeakersStore(db)
+    const speakers = createD1SpeakersStore({ db, config })
     const notifications = createD1NotificationLog(db)
     const assets = createR2AssetStorage(env.SPONSOR_ASSETS)
 

--- a/core/website/app/lib/services/cloudflare/d1-speakers-store.server.ts
+++ b/core/website/app/lib/services/cloudflare/d1-speakers-store.server.ts
@@ -1,3 +1,14 @@
+import { conferenceManifest } from '@conference/manifest'
+import { recordException } from '../../record-exception'
+import { getConfSessions, getConfSpeakers } from '../../sessionize.server'
+import {
+    resolveSpeakerPortalSessionizeEndpoint,
+    toPortalSession,
+    toPortalSpeaker,
+    type PortalSessionContent,
+    type PortalSpeakerContent,
+} from '../../speakers/map-sessionize'
+import type { AppConfig } from '../app-config'
 import type {
     PresentationDetail,
     QuestionsPreference,
@@ -17,28 +28,24 @@ import type {
 interface SpeakerRow {
     sessionize_id: string
     year: string
-    full_name: string
-    tag_line: string | null
-    bio: string | null
-    profile_picture_url: string | null
-    links_json: string | null
     active: number
 }
 
 interface SpeakerSessionRow {
     sessionize_speaker_id: string
     sessionize_session_id: string
-    session_title: string
-    description: string | null
-    format: string | null
-    level: string | null
-    general_topic: string | null
-    talk_topics_json: string | null
-    starts_at: string | null
-    ends_at: string | null
-    room_name: string | null
-    status: string
-    is_confirmed: number
+}
+
+/** Used when a linked id isn't found in the live Sessionize payload — either
+ * Sessionize is unreachable, or the id was removed there since the last
+ * hourly sync caught up. Keeps the portal's checklist/RSVP flows usable
+ * instead of erroring the whole page out. */
+function placeholderSpeaker(sessionizeId: string): PortalSpeakerContent {
+    return { fullName: sessionizeId, links: [] }
+}
+
+function placeholderSession(sessionizeSessionId: string): PortalSessionContent {
+    return { sessionTitle: sessionizeSessionId, talkTopics: [], status: 'Unknown', isConfirmed: false }
 }
 
 interface SpeakerProfileRow {
@@ -98,42 +105,63 @@ function parseJsonArray(json: string | null): string[] {
     }
 }
 
-function toSpeaker(row: SpeakerRow): SpeakerRecord {
-    let links: SpeakerRecord['links'] = []
-    if (row.links_json) {
-        try {
-            const value: unknown = JSON.parse(row.links_json)
-            if (Array.isArray(value)) links = value as SpeakerRecord['links']
-        } catch {
-            // Corrupt JSON shouldn't take the profile page down.
-        }
-    }
+function toSpeaker(row: SpeakerRow, content: PortalSpeakerContent): SpeakerRecord {
     return {
         sessionizeId: row.sessionize_id,
         year: row.year,
-        fullName: row.full_name,
-        tagLine: row.tag_line ?? undefined,
-        bio: row.bio ?? undefined,
-        profilePictureUrl: row.profile_picture_url ?? undefined,
-        links,
+        fullName: content.fullName,
+        tagLine: content.tagLine,
+        bio: content.bio,
+        profilePictureUrl: content.profilePictureUrl,
+        links: content.links,
         active: row.active === 1,
     }
 }
 
-function toSession(row: SpeakerSessionRow): SpeakerSession {
+function toSession(row: SpeakerSessionRow, content: PortalSessionContent): SpeakerSession {
     return {
         sessionizeSessionId: row.sessionize_session_id,
-        sessionTitle: row.session_title,
-        description: row.description ?? undefined,
-        format: row.format ?? undefined,
-        level: row.level ?? undefined,
-        generalTopic: row.general_topic ?? undefined,
-        talkTopics: parseJsonArray(row.talk_topics_json),
-        startsAt: row.starts_at ?? undefined,
-        endsAt: row.ends_at ?? undefined,
-        roomName: row.room_name ?? undefined,
-        status: row.status,
-        isConfirmed: row.is_confirmed === 1,
+        sessionTitle: content.sessionTitle,
+        description: content.description,
+        format: content.format,
+        level: content.level,
+        generalTopic: content.generalTopic,
+        talkTopics: content.talkTopics,
+        startsAt: content.startsAt,
+        endsAt: content.endsAt,
+        roomName: content.roomName,
+        status: content.status,
+        isConfirmed: content.isConfirmed,
+    }
+}
+
+/** Every speaker/session's live Sessionize content, keyed by id — fetched
+ * once per store call and merged with D1 rows by the caller. Reuses
+ * sessionize.server.ts's own 5-minute cache, so this rarely hits the network.
+ * Falls back to an empty map (every id resolves to a placeholder) rather
+ * than throwing, so a Sessionize outage degrades the portal's display
+ * content instead of breaking its checklist/RSVP flows outright. */
+async function fetchLiveContent(
+    config: AppConfig,
+): Promise<{ speakers: Map<string, PortalSpeakerContent>; sessions: Map<string, PortalSessionContent> }> {
+    const empty = { speakers: new Map<string, PortalSpeakerContent>(), sessions: new Map<string, PortalSessionContent>() }
+
+    const sessionizeEndpoint = resolveSpeakerPortalSessionizeEndpoint(config)
+    const categoryNames = conferenceManifest.speakerPortal?.sessionizeCategoryNames
+    if (!sessionizeEndpoint || !categoryNames) return empty
+
+    try {
+        const [speakers, sessions] = await Promise.all([
+            getConfSpeakers({ sessionizeEndpoint }),
+            getConfSessions({ sessionizeEndpoint }),
+        ])
+        return {
+            speakers: new Map(speakers.map((s) => [s.id, toPortalSpeaker(s)])),
+            sessions: new Map(sessions.map((s) => [s.id, toPortalSession(s, categoryNames)])),
+        }
+    } catch (error) {
+        recordException(error)
+        return empty
     }
 }
 
@@ -188,7 +216,9 @@ function toSyncRun(row: SyncRunRow): SpeakerSyncRun {
     }
 }
 
-export function createD1SpeakersStore(db: D1Database): SpeakersStore {
+export function createD1SpeakersStore(args: { db: D1Database; config: AppConfig }): SpeakersStore {
+    const { db, config } = args
+
     return {
         async isSpeakerContact(email) {
             const row = await db
@@ -212,7 +242,9 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
                 )
                 .bind(email.toLowerCase())
                 .first<SpeakerRow>()
-            return row ? toSpeaker(row) : null
+            if (!row) return null
+            const live = await fetchLiveContent(config)
+            return toSpeaker(row, live.speakers.get(row.sessionize_id) ?? placeholderSpeaker(row.sessionize_id))
         },
 
         async getSpeaker(sessionizeId) {
@@ -220,7 +252,9 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
                 .prepare(`SELECT * FROM speakers WHERE sessionize_id = ?`)
                 .bind(sessionizeId)
                 .first<SpeakerRow>()
-            return row ? toSpeaker(row) : null
+            if (!row) return null
+            const live = await fetchLiveContent(config)
+            return toSpeaker(row, live.speakers.get(sessionizeId) ?? placeholderSpeaker(sessionizeId))
         },
 
         async getContactEmails(sessionizeId) {
@@ -292,17 +326,31 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
         },
 
         async getWorkspace(sessionizeId) {
-            const speaker = await this.getSpeaker(sessionizeId)
-            if (!speaker) return null
+            const speakerRow = await db
+                .prepare(`SELECT * FROM speakers WHERE sessionize_id = ?`)
+                .bind(sessionizeId)
+                .first<SpeakerRow>()
+            if (!speakerRow) return null
 
             const mySessions = await db
-                .prepare(`SELECT * FROM speaker_sessions WHERE sessionize_speaker_id = ? ORDER BY starts_at`)
+                .prepare(`SELECT * FROM speaker_sessions WHERE sessionize_speaker_id = ?`)
                 .bind(sessionizeId)
                 .all<SpeakerSessionRow>()
 
+            const live = await fetchLiveContent(config)
+            const speaker = toSpeaker(speakerRow, live.speakers.get(sessionizeId) ?? placeholderSpeaker(sessionizeId))
+
+            // Sort by live start time now that it isn't a D1 column to `ORDER BY`
+            // — undefined (waitlisted, no slot yet) sorts first, same as before.
+            const sessionRows = [...(mySessions.results ?? [])].sort((a, b) => {
+                const aStarts = live.sessions.get(a.sessionize_session_id)?.startsAt ?? ''
+                const bStarts = live.sessions.get(b.sessionize_session_id)?.startsAt ?? ''
+                return aStarts.localeCompare(bStarts)
+            })
+
             const workspace: SpeakerWorkspace = { speaker, sessions: [] }
 
-            for (const sessionRow of mySessions.results ?? []) {
+            for (const sessionRow of sessionRows) {
                 const presenterRows = await db
                     .prepare(
                         `SELECT sp.* FROM speaker_sessions ss
@@ -314,13 +362,17 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
 
                 const presenters = await Promise.all(
                     (presenterRows.results ?? []).map(async (row) => ({
-                        speaker: toSpeaker(row),
+                        speaker: toSpeaker(row, live.speakers.get(row.sessionize_id) ?? placeholderSpeaker(row.sessionize_id)),
                         profile: await this.getProfile(row.sessionize_id),
                     })),
                 )
 
                 workspace.sessions.push({
-                    session: toSession(sessionRow),
+                    session: toSession(
+                        sessionRow,
+                        live.sessions.get(sessionRow.sessionize_session_id) ??
+                            placeholderSession(sessionRow.sessionize_session_id),
+                    ),
                     sessionDetails: await this.getSessionDetails(sessionRow.sessionize_session_id),
                     presenters,
                 })
@@ -330,8 +382,8 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
         },
 
         async listSpeakers(year) {
-            const [speakers, contacts, sessions, profiles, sessionDetailsRows] = await Promise.all([
-                db.prepare(`SELECT * FROM speakers WHERE year = ? ORDER BY full_name`).bind(year).all<SpeakerRow>(),
+            const [speakersResult, contacts, sessions, profiles, sessionDetailsRows, live] = await Promise.all([
+                db.prepare(`SELECT * FROM speakers WHERE year = ?`).bind(year).all<SpeakerRow>(),
                 db
                     .prepare(
                         `SELECT c.email, c.sessionize_id FROM speaker_contacts c
@@ -362,6 +414,7 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
                     )
                     .bind(year)
                     .all<{ sessionize_session_id: string; questions_preference: string | null }>(),
+                fetchLiveContent(config),
             ])
 
             const contactsBySpeaker = new Map<string, string[]>()
@@ -373,7 +426,7 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
             const sessionsBySpeaker = new Map<string, SpeakerSession[]>()
             for (const s of sessions.results ?? []) {
                 const list = sessionsBySpeaker.get(s.sessionize_speaker_id) ?? []
-                list.push(toSession(s))
+                list.push(toSession(s, live.sessions.get(s.sessionize_session_id) ?? placeholderSession(s.sessionize_session_id)))
                 sessionsBySpeaker.set(s.sessionize_speaker_id, list)
             }
             const profileBySpeaker = new Map((profiles.results ?? []).map((p) => [p.sessionize_id, toProfile(p)]))
@@ -381,10 +434,10 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
                 (sessionDetailsRows.results ?? []).map((r) => [r.sessionize_session_id, Boolean(r.questions_preference)]),
             )
 
-            return (speakers.results ?? []).map((row): SpeakerListEntry => {
+            const entries = (speakersResult.results ?? []).map((row): SpeakerListEntry => {
                 const speakerSessions = sessionsBySpeaker.get(row.sessionize_id) ?? []
                 return {
-                    ...toSpeaker(row),
+                    ...toSpeaker(row, live.speakers.get(row.sessionize_id) ?? placeholderSpeaker(row.sessionize_id)),
                     contacts: contactsBySpeaker.get(row.sessionize_id) ?? [],
                     sessions: speakerSessions,
                     profile: profileBySpeaker.get(row.sessionize_id) ?? null,
@@ -396,6 +449,11 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
                     ),
                 }
             })
+
+            // Was `ORDER BY full_name` in SQL — full_name is no longer a D1
+            // column, so sort the live-merged list instead.
+            entries.sort((a, b) => a.fullName.localeCompare(b.fullName))
+            return entries
         },
 
         async getAllSpeakersForSync() {
@@ -417,7 +475,7 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
         },
 
         async saveProfile(sessionizeId, details, updatedBy) {
-            // Deliberately doesn't touch rsvp_speakers_dinner /
+            // Deliberately doesn't touch dietary_requirements / rsvp_speakers_dinner /
             // rsvp_speaker_training_json / rsvp_speaker_training_responded_at /
             // register_meet_the_experts_slots_json / register_meet_the_experts_responded_at
             // — those are owned by saveSpeakerDinnerRsvp / saveSpeakerTrainingRsvp /
@@ -427,14 +485,13 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
                 .prepare(
                     `INSERT INTO speaker_profiles
                          (sessionize_id, name_phonetic_spelling, introduction_use_sessionize_bio,
-                          introduction_custom_text, dietary_requirements, register_meet_the_experts,
+                          introduction_custom_text, register_meet_the_experts,
                           register_meet_the_experts_other, updated_at, updated_by)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, unixepoch(), ?)
+                     VALUES (?, ?, ?, ?, ?, ?, unixepoch(), ?)
                      ON CONFLICT(sessionize_id) DO UPDATE SET
                          name_phonetic_spelling = excluded.name_phonetic_spelling,
                          introduction_use_sessionize_bio = excluded.introduction_use_sessionize_bio,
                          introduction_custom_text = excluded.introduction_custom_text,
-                         dietary_requirements = excluded.dietary_requirements,
                          register_meet_the_experts = excluded.register_meet_the_experts,
                          register_meet_the_experts_other = excluded.register_meet_the_experts_other,
                          updated_at = excluded.updated_at,
@@ -445,7 +502,6 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
                     details.namePhoneticSpelling ?? null,
                     details.introductionUseSessionizeBio ? 1 : 0,
                     details.introductionCustomText ?? null,
-                    details.dietaryRequirements ?? null,
                     details.registerMeetTheExperts ?? null,
                     details.registerMeetTheExpertsOther ?? null,
                     updatedBy,
@@ -554,15 +610,17 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
                 .run()
         },
 
-        async saveSpeakerDinnerRsvp(sessionizeId, response, updatedBy) {
+        async saveSpeakerDinnerRsvp(sessionizeId, response, dietaryRequirements, updatedBy) {
             await db
                 .prepare(
-                    `INSERT INTO speaker_profiles (sessionize_id, rsvp_speakers_dinner, updated_at, updated_by)
-                     VALUES (?, ?, unixepoch(), ?)
+                    `INSERT INTO speaker_profiles
+                         (sessionize_id, rsvp_speakers_dinner, dietary_requirements, updated_at, updated_by)
+                     VALUES (?, ?, ?, unixepoch(), ?)
                      ON CONFLICT(sessionize_id) DO UPDATE SET
-                         rsvp_speakers_dinner = excluded.rsvp_speakers_dinner`,
+                         rsvp_speakers_dinner = excluded.rsvp_speakers_dinner,
+                         dietary_requirements = excluded.dietary_requirements`,
                 )
-                .bind(sessionizeId, response, updatedBy)
+                .bind(sessionizeId, response, dietaryRequirements ?? null, updatedBy)
                 .run()
         },
 
@@ -595,29 +653,14 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
                 statements.push(
                     db
                         .prepare(
-                            `INSERT INTO speakers
-                                 (sessionize_id, year, full_name, tag_line, bio, profile_picture_url, links_json,
-                                  active, created_at, updated_at)
-                             VALUES (?, ?, ?, ?, ?, ?, ?, 1, unixepoch(), unixepoch())
+                            `INSERT INTO speakers (sessionize_id, year, active, created_at, updated_at)
+                             VALUES (?, ?, 1, unixepoch(), unixepoch())
                              ON CONFLICT(sessionize_id) DO UPDATE SET
                                  year = excluded.year,
-                                 full_name = excluded.full_name,
-                                 tag_line = excluded.tag_line,
-                                 bio = excluded.bio,
-                                 profile_picture_url = excluded.profile_picture_url,
-                                 links_json = excluded.links_json,
                                  active = 1,
                                  updated_at = excluded.updated_at`,
                         )
-                        .bind(
-                            s.sessionizeId,
-                            s.year,
-                            s.fullName,
-                            s.tagLine ?? null,
-                            s.bio ?? null,
-                            s.profilePictureUrl ?? null,
-                            s.links.length > 0 ? JSON.stringify(s.links) : null,
-                        ),
+                        .bind(s.sessionizeId, s.year),
                 )
             }
             for (const sessionizeId of plan.deactivateSessionizeIds) {
@@ -631,40 +674,12 @@ export function createD1SpeakersStore(db: D1Database): SpeakersStore {
                 statements.push(
                     db
                         .prepare(
-                            `INSERT INTO speaker_sessions
-                                 (sessionize_speaker_id, sessionize_session_id, session_title, description, format,
-                                  level, general_topic, talk_topics_json, starts_at, ends_at, room_name, status,
-                                  is_confirmed, updated_at)
-                             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, unixepoch())
+                            `INSERT INTO speaker_sessions (sessionize_speaker_id, sessionize_session_id, updated_at)
+                             VALUES (?, ?, unixepoch())
                              ON CONFLICT(sessionize_speaker_id, sessionize_session_id) DO UPDATE SET
-                                 session_title = excluded.session_title,
-                                 description = excluded.description,
-                                 format = excluded.format,
-                                 level = excluded.level,
-                                 general_topic = excluded.general_topic,
-                                 talk_topics_json = excluded.talk_topics_json,
-                                 starts_at = excluded.starts_at,
-                                 ends_at = excluded.ends_at,
-                                 room_name = excluded.room_name,
-                                 status = excluded.status,
-                                 is_confirmed = excluded.is_confirmed,
                                  updated_at = excluded.updated_at`,
                         )
-                        .bind(
-                            s.sessionizeSpeakerId,
-                            s.sessionizeSessionId,
-                            s.sessionTitle,
-                            s.description ?? null,
-                            s.format ?? null,
-                            s.level ?? null,
-                            s.generalTopic ?? null,
-                            s.talkTopics.length > 0 ? JSON.stringify(s.talkTopics) : null,
-                            s.startsAt ?? null,
-                            s.endsAt ?? null,
-                            s.roomName ?? null,
-                            s.status,
-                            s.isConfirmed ? 1 : 0,
-                        ),
+                        .bind(s.sessionizeSpeakerId, s.sessionizeSessionId),
                 )
             }
             for (const r of plan.sessionRemovals) {

--- a/core/website/app/lib/services/cloudflare/sessionize-speaker-sync.server.ts
+++ b/core/website/app/lib/services/cloudflare/sessionize-speaker-sync.server.ts
@@ -1,8 +1,6 @@
 import { conferenceManifest } from '@conference/manifest'
-import type { sessionSchema } from '@ddd/conference-config'
-import type { z } from 'zod'
-import { getYearConfig } from '../../get-year-config.server'
-import { getConfSessions, getConfSpeakers } from '../../sessionize.server'
+import { resolveSpeakerPortalSessionizeEndpoint } from '../../speakers/map-sessionize'
+import { getConfSessions } from '../../sessionize.server'
 import { computeSpeakerSyncPlan, type SyncSourceSession } from '../../speakers/sync-plan'
 import type { AppConfig } from '../app-config'
 import type { SpeakerSyncService } from '../speaker-sync-service'
@@ -14,42 +12,20 @@ import type { SpeakersStore } from '../speakers-store'
  */
 const STALE_RUN_SECONDS = 5 * 60
 
-type Session = z.infer<typeof sessionSchema>
-
-/** All category-item names under the category matching `categoryName`
- * (case-sensitive, matched on Sessionize's own category name). Empty array
- * if the category doesn't exist on this session — a category set up after
- * some sessions were submitted shouldn't break the sync. */
-function categoryValues(session: Session, categoryName: string): string[] {
-    const category = session.categories.find((c) => c.name === categoryName)
-    return category ? category.categoryItems.map((item) => item.name) : []
-}
-
-/** Single-select convenience — first value, if any. */
-function categoryValue(session: Session, categoryName: string): string | undefined {
-    return categoryValues(session, categoryName)[0]
-}
-
 export function createSessionizeSpeakerSyncService(args: { config: AppConfig; speakers: SpeakersStore }): SpeakerSyncService {
     const { config, speakers } = args
     const portalConfig = conferenceManifest.speakerPortal
 
-    function sessionizeEndpointFor(year: string): string | undefined {
-        const yearConfig = getYearConfig(year, config)
-        if (yearConfig.kind !== 'conference' || yearConfig.sessions?.kind !== 'sessionize') return undefined
-        return yearConfig.sessions.sessionizeEndpoint
-    }
-
     return {
         isConfigured() {
-            return Boolean(portalConfig && sessionizeEndpointFor(portalConfig.year))
+            return Boolean(portalConfig && resolveSpeakerPortalSessionizeEndpoint(config))
         },
 
         async syncNow(trigger) {
             if (!portalConfig) {
                 return { ok: false, reason: 'not-configured' }
             }
-            const sessionizeEndpoint = sessionizeEndpointFor(portalConfig.year)
+            const sessionizeEndpoint = resolveSpeakerPortalSessionizeEndpoint(config)
             if (!sessionizeEndpoint) {
                 return { ok: false, reason: 'not-configured' }
             }
@@ -61,46 +37,23 @@ export function createSessionizeSpeakerSyncService(args: { config: AppConfig; sp
 
             const runId = await speakers.startSyncRun(trigger)
             try {
-                const [allSessions, allSpeakers, currentSpeakers, currentSpeakerSessions] = await Promise.all([
+                const [allSessions, currentSpeakers, currentSpeakerSessions] = await Promise.all([
                     getConfSessions({ sessionizeEndpoint }),
-                    getConfSpeakers({ sessionizeEndpoint }),
                     speakers.getAllSpeakersForSync(),
                     speakers.getAllSpeakerSessions(),
                 ])
 
-                const { format, level, generalTopic, talkTopics } = portalConfig.sessionizeCategoryNames
                 const accessStatuses = new Set(portalConfig.portalAccessStatuses)
                 const sessions: SyncSourceSession[] = allSessions
                     .filter((s) => s.status && accessStatuses.has(s.status))
                     .map((s) => ({
                         sessionizeSessionId: s.id,
-                        sessionTitle: s.title,
-                        description: s.description ?? undefined,
-                        format: categoryValue(s, format),
-                        level: categoryValue(s, level),
-                        generalTopic: categoryValue(s, generalTopic),
-                        talkTopics: categoryValues(s, talkTopics),
-                        startsAt: s.startsAt ?? undefined,
-                        endsAt: s.endsAt ?? undefined,
-                        roomName: s.room ?? undefined,
-                        status: s.status ?? 'Unknown',
-                        isConfirmed: s.isConfirmed,
                         speakerIds: s.speakers.map((sp) => sp.id),
                     }))
-
-                const speakerInfo = allSpeakers.map((s) => ({
-                    sessionizeId: s.id,
-                    fullName: s.fullName,
-                    tagLine: s.tagLine,
-                    bio: s.bio ?? undefined,
-                    profilePictureUrl: s.profilePicture ?? undefined,
-                    links: s.links,
-                }))
 
                 const plan = computeSpeakerSyncPlan({
                     year: portalConfig.year,
                     sessions,
-                    speakerInfo,
                     currentSpeakers,
                     currentSpeakerSessions,
                 })

--- a/core/website/app/lib/services/speakers-store.ts
+++ b/core/website/app/lib/services/speakers-store.ts
@@ -73,6 +73,8 @@ export interface SpeakerProfile {
     /** True = use their Sessionize bio as-is; false = use introductionCustomText. */
     introductionUseSessionizeBio: boolean
     introductionCustomText?: string
+    /** RSVP'd through its own dedicated modal, not the main session-details
+     * form — see `saveSpeakerDinnerRsvp`. */
     dietaryRequirements?: string
     registerMeetTheExperts?: YesNoMaybeOther
     registerMeetTheExpertsOther?: string
@@ -120,7 +122,8 @@ export interface SpeakerProfile {
 }
 
 /** Everything the session-details modal's `save-profile` action accepts —
- * same shape as `SpeakerProfile` minus the fields the store computes itself
+ * same shape as `SpeakerProfile` minus the fields the store computes itself,
+ * dietary requirements (asked as part of the speaker dinner RSVP instead),
  * and the RSVPs, which are saved through their own dedicated actions
  * (`saveSpeakerTrainingRsvp` / `saveSpeakerDinnerRsvp` / `saveMeetTheExpertsSlots`)
  * so that submitting this form can never clobber an RSVP already on file. */
@@ -131,6 +134,7 @@ export type SpeakerProfileInput = Omit<
     | 'updatedAt'
     | 'updatedBy'
     | 'ticketClaimedAt'
+    | 'dietaryRequirements'
     | 'rsvpSpeakersDinner'
     | 'rsvpSpeakerTraining'
     | 'rsvpSpeakerTrainingRespondedAt'
@@ -181,35 +185,14 @@ export interface SpeakerWorkspace {
 }
 
 /** Result of diffing Sessionize against current D1 state. Computed by the
- * pure `computeSpeakerSyncPlan()` in lib/speakers/sync-plan.ts. Contacts
- * aren't part of this — they're admin-managed directly in D1, independent
- * of the sync. */
+ * pure `computeSpeakerSyncPlan()` in lib/speakers/sync-plan.ts. Only ids and
+ * linkage — Sessionize content (name, bio, session title, etc.) is read live
+ * at request time instead of synced in. Contacts aren't part of this either
+ * — they're admin-managed directly in D1, independent of the sync. */
 export interface SpeakerSyncPlan {
-    upserts: Array<{
-        sessionizeId: string
-        year: string
-        fullName: string
-        tagLine?: string
-        bio?: string
-        profilePictureUrl?: string
-        links: SpeakerLink[]
-    }>
+    upserts: Array<{ sessionizeId: string; year: string }>
     deactivateSessionizeIds: string[]
-    sessionUpserts: Array<{
-        sessionizeSpeakerId: string
-        sessionizeSessionId: string
-        sessionTitle: string
-        description?: string
-        format?: string
-        level?: string
-        generalTopic?: string
-        talkTopics: string[]
-        startsAt?: string
-        endsAt?: string
-        roomName?: string
-        status: string
-        isConfirmed: boolean
-    }>
+    sessionUpserts: Array<{ sessionizeSpeakerId: string; sessionizeSessionId: string }>
     /** Session rows for speakers no longer accepted/waitlisted — removed outright. */
     sessionRemovals: Array<{ sessionizeSpeakerId: string; sessionizeSessionId: string }>
 }
@@ -307,9 +290,16 @@ export interface SpeakersStore {
         updatedBy: string,
     ): Promise<void>
 
-    /** Speaker-dinner RSVP, from its own modal. Same idiom as
-     * saveSpeakerTrainingRsvp — only touches rsvp_speakers_dinner. */
-    saveSpeakerDinnerRsvp(sessionizeId: string, response: YesNoMaybe, updatedBy: string): Promise<void>
+    /** Speaker-dinner RSVP, from its own modal — also where dietary
+     * requirements are asked, since that's only relevant if they're
+     * attending. Same idiom as saveSpeakerTrainingRsvp — only touches
+     * rsvp_speakers_dinner and dietary_requirements. */
+    saveSpeakerDinnerRsvp(
+        sessionizeId: string,
+        response: YesNoMaybe,
+        dietaryRequirements: string | undefined,
+        updatedBy: string,
+    ): Promise<void>
 
     /** Self-reported "I've already confirmed it" from the checklist.
      * Idempotent — stamps `sessionConfirmedReportedAt` only the first time,

--- a/core/website/app/lib/speakers/checklist-items.ts
+++ b/core/website/app/lib/speakers/checklist-items.ts
@@ -70,7 +70,7 @@ export const SPEAKER_CHECKLIST_ITEMS: ChecklistItemDefinition[] = [
         dueDate: DateTime.fromISO('2026-09-11T22:00:00', { zone: 'Australia/Perth' }),
         actions: [
             // href omitted — falls back to the dynamic ticketClaimUrl prop.
-            { label: 'Claim your ticket ↗' },
+            { label: 'Claim your ticket ↗', href: 'https://ti.to/dddperth/2026/with/speaker' },
             { action: 'claim-ticket', label: "I've claimed it" },
         ],
     },

--- a/core/website/app/lib/speakers/checklist.ts
+++ b/core/website/app/lib/speakers/checklist.ts
@@ -9,10 +9,9 @@ import type { SpeakerProfile } from '../services/speakers-store'
 
 /** Session details = the session-level Q&A preference (shared by every
  * presenter on the session — see `SpeakerSessionChecklistInput`) plus the
- * viewer's own introduction. Doesn't require every optional field (dietary
- * requirements, "anything else", etc) — just enough that the organisers
- * aren't missing the essentials. A speaker with no sessions has nothing to
- * fill in yet. */
+ * viewer's own introduction. Doesn't require every optional field ("anything
+ * else", etc) — just enough that the organisers aren't missing the
+ * essentials. A speaker with no sessions has nothing to fill in yet. */
 export function isSessionDetailsComplete(
     profile: SpeakerProfile | null,
     sessions: SpeakerSessionChecklistInput[],

--- a/core/website/app/lib/speakers/dashboard-view.server.ts
+++ b/core/website/app/lib/speakers/dashboard-view.server.ts
@@ -43,6 +43,7 @@ export interface SpeakerDashboardView {
     dinnerDateLabel: string | null
     dinnerCalendarUrl: string | null
     dinnerResponse: YesNoMaybe | undefined
+    dinnerDietaryRequirements: string | undefined
 
     meetTheExpertsSlots: Array<{ id: string; label: string }>
     meetTheExpertsResponded: boolean
@@ -134,6 +135,7 @@ export function buildSpeakerDashboardView(
               })
             : null,
         dinnerResponse: ownProfile?.rsvpSpeakersDinner,
+        dinnerDietaryRequirements: ownProfile?.dietaryRequirements,
 
         meetTheExpertsSlots: checklistConfig?.meetTheExpertsSlots ?? [],
         meetTheExpertsResponded: Boolean(ownProfile?.registerMeetTheExpertsRespondedAt),

--- a/core/website/app/lib/speakers/map-sessionize.ts
+++ b/core/website/app/lib/speakers/map-sessionize.ts
@@ -1,0 +1,98 @@
+import { conferenceManifest } from '@conference/manifest'
+import type { sessionSchema } from '@ddd/conference-config'
+import type { z } from 'zod'
+import { getYearConfig } from '../get-year-config.server'
+import type { speakersSchema } from '../sessionize.server'
+import type { AppConfig } from '../services/app-config'
+import type { SpeakerLink } from '../services/speakers-store'
+
+/**
+ * Maps raw Sessionize payloads (`getConfSessions`/`getConfSpeakers`) to the
+ * portal's display shape. Shared by the D1 store's read path (live content,
+ * merged with D1 ids/extras) and, for the endpoint resolver only, the sync
+ * service (which just needs to know which speaker ids are on
+ * accepted/waitlisted sessions, not their content).
+ */
+
+type Session = z.infer<typeof sessionSchema>
+type SessionizeSpeaker = z.infer<typeof speakersSchema>[number]
+
+/** All category-item names under the category matching `categoryName`
+ * (case-sensitive, matched on Sessionize's own category name). Empty array
+ * if the category doesn't exist on this session — a category set up after
+ * some sessions were submitted shouldn't break the mapping. */
+export function categoryValues(session: Session, categoryName: string): string[] {
+    const category = session.categories.find((c) => c.name === categoryName)
+    return category ? category.categoryItems.map((item) => item.name) : []
+}
+
+/** Single-select convenience — first value, if any. */
+export function categoryValue(session: Session, categoryName: string): string | undefined {
+    return categoryValues(session, categoryName)[0]
+}
+
+export interface PortalCategoryNames {
+    format: string
+    level: string
+    generalTopic: string
+    talkTopics: string
+}
+
+export interface PortalSpeakerContent {
+    fullName: string
+    tagLine?: string
+    bio?: string
+    profilePictureUrl?: string
+    links: SpeakerLink[]
+}
+
+export interface PortalSessionContent {
+    sessionTitle: string
+    description?: string
+    format?: string
+    level?: string
+    generalTopic?: string
+    talkTopics: string[]
+    startsAt?: string
+    endsAt?: string
+    roomName?: string
+    status: string
+    isConfirmed: boolean
+}
+
+export function toPortalSpeaker(speaker: SessionizeSpeaker): PortalSpeakerContent {
+    return {
+        fullName: speaker.fullName,
+        tagLine: speaker.tagLine,
+        bio: speaker.bio ?? undefined,
+        profilePictureUrl: speaker.profilePicture ?? undefined,
+        links: speaker.links,
+    }
+}
+
+export function toPortalSession(session: Session, categoryNames: PortalCategoryNames): PortalSessionContent {
+    return {
+        sessionTitle: session.title,
+        description: session.description ?? undefined,
+        format: categoryValue(session, categoryNames.format),
+        level: categoryValue(session, categoryNames.level),
+        generalTopic: categoryValue(session, categoryNames.generalTopic),
+        talkTopics: categoryValues(session, categoryNames.talkTopics),
+        startsAt: session.startsAt ?? undefined,
+        endsAt: session.endsAt ?? undefined,
+        roomName: session.room ?? undefined,
+        status: session.status ?? 'Unknown',
+        isConfirmed: session.isConfirmed,
+    }
+}
+
+/** The Sessionize endpoint configured for the speaker portal's year, if any
+ * — same resolution the sync service uses. */
+export function resolveSpeakerPortalSessionizeEndpoint(config: AppConfig): string | undefined {
+    const portalConfig = conferenceManifest.speakerPortal
+    if (!portalConfig) return undefined
+
+    const yearConfig = getYearConfig(portalConfig.year, config)
+    if (yearConfig.kind !== 'conference' || yearConfig.sessions?.kind !== 'sessionize') return undefined
+    return yearConfig.sessions.sessionizeEndpoint
+}

--- a/core/website/app/lib/speakers/profile-form.server.ts
+++ b/core/website/app/lib/speakers/profile-form.server.ts
@@ -9,7 +9,7 @@ import {
     type YesNoMaybeOther,
 } from '../services/speakers-store'
 
-function emptyToUndefined(value: FormDataEntryValue | null): string | undefined {
+export function emptyToUndefined(value: FormDataEntryValue | null): string | undefined {
     if (typeof value !== 'string') return undefined
     const trimmed = value.trim()
     return trimmed.length > 0 ? trimmed : undefined
@@ -66,7 +66,6 @@ export function parseSpeakerProfileForm(formData: FormData, sessionizeId: string
         namePhoneticSpelling: emptyToUndefined(formData.get(`namePhoneticSpelling-${sessionizeId}`)),
         introductionUseSessionizeBio: formData.get(`introductionSource-${sessionizeId}`) !== 'custom',
         introductionCustomText: emptyToUndefined(formData.get(`introductionCustomText-${sessionizeId}`)),
-        dietaryRequirements: emptyToUndefined(formData.get(`dietaryRequirements-${sessionizeId}`)),
         registerMeetTheExperts: oneOf<YesNoMaybeOther>(
             formData.get(`registerMeetTheExperts-${sessionizeId}`),
             YES_NO_MAYBE_OTHER_OPTIONS,

--- a/core/website/app/lib/speakers/sync-plan.test.ts
+++ b/core/website/app/lib/speakers/sync-plan.test.ts
@@ -1,27 +1,21 @@
 import { describe, expect, it } from 'vitest'
-import { computeSpeakerSyncPlan, type SyncSourceSession, type SyncSourceSpeakerInfo } from './sync-plan'
+import { computeSpeakerSyncPlan, type SyncSourceSession } from './sync-plan'
 
 function session(overrides: Partial<SyncSourceSession> & { sessionizeSessionId: string }): SyncSourceSession {
     return {
-        sessionTitle: 'A Talk',
-        status: 'Accepted',
         speakerIds: [],
-        talkTopics: [],
-        isConfirmed: false,
         ...overrides,
     }
 }
 
 function baseArgs(overrides: {
     sessions?: SyncSourceSession[]
-    speakerInfo?: SyncSourceSpeakerInfo[]
     currentSpeakers?: Array<{ sessionizeId: string; active: boolean }>
     currentSpeakerSessions?: Array<{ sessionizeSpeakerId: string; sessionizeSessionId: string }>
 }) {
     return {
         year: '2026',
         sessions: overrides.sessions ?? [],
-        speakerInfo: overrides.speakerInfo ?? [],
         currentSpeakers: overrides.currentSpeakers ?? [],
         currentSpeakerSessions: overrides.currentSpeakerSessions ?? [],
     }
@@ -32,29 +26,11 @@ describe('computeSpeakerSyncPlan', () => {
         const plan = computeSpeakerSyncPlan(
             baseArgs({
                 sessions: [session({ sessionizeSessionId: 'SESS-1', speakerIds: ['SPK-1'] })],
-                speakerInfo: [{ sessionizeId: 'SPK-1', fullName: 'Ada Lovelace' }],
             }),
         )
 
-        expect(plan.upserts).toEqual([
-            {
-                sessionizeId: 'SPK-1',
-                year: '2026',
-                fullName: 'Ada Lovelace',
-                tagLine: undefined,
-                bio: undefined,
-                profilePictureUrl: undefined,
-                links: [],
-            },
-        ])
+        expect(plan.upserts).toEqual([{ sessionizeId: 'SPK-1', year: '2026' }])
         expect(plan.deactivateSessionizeIds).toEqual([])
-    })
-
-    it('falls back to the sessionize id as the name when speaker info is missing', () => {
-        const plan = computeSpeakerSyncPlan(
-            baseArgs({ sessions: [session({ sessionizeSessionId: 'SESS-1', speakerIds: ['SPK-1'] })] }),
-        )
-        expect(plan.upserts[0].fullName).toBe('SPK-1')
     })
 
     it('deactivates active speakers no longer accepted/waitlisted', () => {
@@ -74,116 +50,14 @@ describe('computeSpeakerSyncPlan', () => {
     it('produces a session row per co-presenter on a shared session', () => {
         const plan = computeSpeakerSyncPlan(
             baseArgs({
-                sessions: [
-                    session({
-                        sessionizeSessionId: 'SESS-1',
-                        sessionTitle: 'Pair talk',
-                        startsAt: '2026-10-03T09:00:00',
-                        endsAt: '2026-10-03T09:45:00',
-                        roomName: 'Main Hall',
-                        speakerIds: ['SPK-1', 'SPK-2'],
-                    }),
-                ],
+                sessions: [session({ sessionizeSessionId: 'SESS-1', speakerIds: ['SPK-1', 'SPK-2'] })],
             }),
         )
 
         expect(plan.sessionUpserts).toEqual([
-            {
-                sessionizeSpeakerId: 'SPK-1',
-                sessionizeSessionId: 'SESS-1',
-                sessionTitle: 'Pair talk',
-                description: undefined,
-                format: undefined,
-                level: undefined,
-                generalTopic: undefined,
-                talkTopics: [],
-                startsAt: '2026-10-03T09:00:00',
-                endsAt: '2026-10-03T09:45:00',
-                roomName: 'Main Hall',
-                status: 'Accepted',
-                isConfirmed: false,
-            },
-            {
-                sessionizeSpeakerId: 'SPK-2',
-                sessionizeSessionId: 'SESS-1',
-                sessionTitle: 'Pair talk',
-                description: undefined,
-                format: undefined,
-                level: undefined,
-                generalTopic: undefined,
-                talkTopics: [],
-                startsAt: '2026-10-03T09:00:00',
-                endsAt: '2026-10-03T09:45:00',
-                roomName: 'Main Hall',
-                status: 'Accepted',
-                isConfirmed: false,
-            },
+            { sessionizeSpeakerId: 'SPK-1', sessionizeSessionId: 'SESS-1' },
+            { sessionizeSpeakerId: 'SPK-2', sessionizeSessionId: 'SESS-1' },
         ])
-    })
-
-    it('passes through isConfirmed', () => {
-        const plan = computeSpeakerSyncPlan(
-            baseArgs({
-                sessions: [session({ sessionizeSessionId: 'SESS-1', speakerIds: ['SPK-1'], isConfirmed: true })],
-            }),
-        )
-        expect(plan.sessionUpserts[0].isConfirmed).toBe(true)
-    })
-
-    it('passes through description, format, level, general topic, talk topics, and speaker links', () => {
-        const plan = computeSpeakerSyncPlan(
-            baseArgs({
-                sessions: [
-                    session({
-                        sessionizeSessionId: 'SESS-1',
-                        speakerIds: ['SPK-1'],
-                        description: 'A talk about things',
-                        format: '45 mins',
-                        level: 'Mostly intermediate',
-                        generalTopic: 'Software Development',
-                        talkTopics: ['Architecture', 'Backend'],
-                    }),
-                ],
-                speakerInfo: [
-                    {
-                        sessionizeId: 'SPK-1',
-                        fullName: 'Ada Lovelace',
-                        links: [
-                            { title: 'X (Twitter)', url: 'https://twitter.com/ada', linkType: 'Twitter' },
-                            { title: 'LinkedIn', url: 'https://linkedin.com/in/ada', linkType: 'LinkedIn' },
-                        ],
-                    },
-                ],
-            }),
-        )
-
-        expect(plan.sessionUpserts[0]).toMatchObject({
-            description: 'A talk about things',
-            format: '45 mins',
-            level: 'Mostly intermediate',
-            generalTopic: 'Software Development',
-            talkTopics: ['Architecture', 'Backend'],
-        })
-        expect(plan.upserts[0].links).toEqual([
-            { title: 'X (Twitter)', url: 'https://twitter.com/ada', linkType: 'Twitter' },
-            { title: 'LinkedIn', url: 'https://linkedin.com/in/ada', linkType: 'LinkedIn' },
-        ])
-    })
-
-    it('tolerates a waitlisted session with no fixed slot', () => {
-        const plan = computeSpeakerSyncPlan(
-            baseArgs({
-                sessions: [
-                    session({
-                        sessionizeSessionId: 'SESS-2',
-                        status: 'Waitlisted',
-                        speakerIds: ['SPK-3'],
-                    }),
-                ],
-            }),
-        )
-        expect(plan.sessionUpserts[0].startsAt).toBeUndefined()
-        expect(plan.sessionUpserts[0].status).toBe('Waitlisted')
     })
 
     it('removes a (speaker, session) pair no longer in the source', () => {

--- a/core/website/app/lib/speakers/sync-plan.ts
+++ b/core/website/app/lib/speakers/sync-plan.ts
@@ -1,47 +1,22 @@
-import type { SpeakerLink, SpeakerSyncPlan } from '../services/speakers-store'
+import type { SpeakerSyncPlan } from '../services/speakers-store'
 
 /**
  * Pure sync planning: Sessionize sessions in, diff against current D1
  * state, plan out. No I/O — the D1/Sessionize plumbing lives in the sync
  * service. Unit tests in sync-plan.test.ts.
+ *
+ * Only ids and linkage are planned here — Sessionize content (name, bio,
+ * session title, schedule slot, etc.) is read live at request time (see
+ * lib/speakers/map-sessionize.ts) instead of being synced into D1.
  */
 
 /** A session as parsed from Sessionize, already filtered to the statuses
- * that grant portal access (e.g. Accepted/Waitlisted). */
+ * that grant portal access (e.g. Accepted/Waitlisted) — just enough to
+ * compute which speaker/session ids the portal knows about. */
 export interface SyncSourceSession {
     sessionizeSessionId: string
-    sessionTitle: string
-    description?: string
-    /** Sessionize "Session format" category, e.g. "45 mins", "Keynote". */
-    format?: string
-    /** Sessionize "Level" category, e.g. "Mostly intermediate". */
-    level?: string
-    /** Sessionize "General Topic Category" — single-select. */
-    generalTopic?: string
-    /** Sessionize "Talk Topics" — multi-select. */
-    talkTopics: string[]
-    /** Null/undefined until the agenda is published — accepted sessions always
-     * have a slot, it just isn't exposed via the API beforehand. Waitlisted
-     * sessions (backup speakers) never get one. */
-    startsAt?: string
-    endsAt?: string
-    roomName?: string
-    status: string
-    /** Sessionize's "Owner Confirmed" flag — session-level. */
-    isConfirmed: boolean
     /** Sessionize speaker ids presenting this session (co-presenters share one row each). */
     speakerIds: string[]
-}
-
-/** Bio/tagline/picture/links for a Sessionize speaker, independent of which
- * session(s) they're on. */
-export interface SyncSourceSpeakerInfo {
-    sessionizeId: string
-    fullName: string
-    tagLine?: string
-    bio?: string
-    profilePictureUrl?: string
-    links?: SpeakerLink[]
 }
 
 /**
@@ -60,31 +35,17 @@ export interface SyncSourceSpeakerInfo {
 export function computeSpeakerSyncPlan(args: {
     year: string
     sessions: SyncSourceSession[]
-    speakerInfo: SyncSourceSpeakerInfo[]
     currentSpeakers: Array<{ sessionizeId: string; active: boolean }>
     currentSpeakerSessions: Array<{ sessionizeSpeakerId: string; sessionizeSessionId: string }>
 }): SpeakerSyncPlan {
-    const { year, sessions, speakerInfo, currentSpeakers, currentSpeakerSessions } = args
-
-    const infoById = new Map(speakerInfo.map((s) => [s.sessionizeId, s]))
+    const { year, sessions, currentSpeakers, currentSpeakerSessions } = args
 
     const activeSpeakerIds = new Set<string>()
     for (const session of sessions) {
         for (const speakerId of session.speakerIds) activeSpeakerIds.add(speakerId)
     }
 
-    const upserts = [...activeSpeakerIds].map((sessionizeId) => {
-        const info = infoById.get(sessionizeId)
-        return {
-            sessionizeId,
-            year,
-            fullName: info?.fullName ?? sessionizeId,
-            tagLine: info?.tagLine,
-            bio: info?.bio,
-            profilePictureUrl: info?.profilePictureUrl,
-            links: info?.links ?? [],
-        }
-    })
+    const upserts = [...activeSpeakerIds].map((sessionizeId) => ({ sessionizeId, year }))
 
     const deactivateSessionizeIds = currentSpeakers
         .filter((s) => s.active && !activeSpeakerIds.has(s.sessionizeId))
@@ -94,17 +55,6 @@ export function computeSpeakerSyncPlan(args: {
         session.speakerIds.map((speakerId) => ({
             sessionizeSpeakerId: speakerId,
             sessionizeSessionId: session.sessionizeSessionId,
-            sessionTitle: session.sessionTitle,
-            description: session.description,
-            format: session.format,
-            level: session.level,
-            generalTopic: session.generalTopic,
-            talkTopics: session.talkTopics,
-            startsAt: session.startsAt,
-            endsAt: session.endsAt,
-            roomName: session.roomName,
-            status: session.status,
-            isConfirmed: session.isConfirmed,
         })),
     )
 

--- a/core/website/app/routes/admin.speakers.$sessionizeId.tsx
+++ b/core/website/app/routes/admin.speakers.$sessionizeId.tsx
@@ -14,7 +14,7 @@ import { SpeakerWorkspaceView } from '~/components/speaker-workspace-view'
 import { requireAdmin } from '~/lib/auth.server'
 import { recordException } from '~/lib/record-exception'
 import { buildSpeakerDashboardView } from '~/lib/speakers/dashboard-view.server'
-import { parseMeetTheExpertsForm, parseSessionDetailsForm, parseSpeakerProfileForm } from '~/lib/speakers/profile-form.server'
+import { emptyToUndefined, parseMeetTheExpertsForm, parseSessionDetailsForm, parseSpeakerProfileForm } from '~/lib/speakers/profile-form.server'
 import { SPEAKER_TRAINING_SESSION_OPTIONS, YES_NO_MAYBE_OPTIONS, type SpeakerTrainingSession, type YesNoMaybe } from '~/lib/services/speakers-store'
 import { getServices } from '~/remix-app-load-context'
 import { Box, styled } from '~/styled-system/jsx'
@@ -124,7 +124,8 @@ export async function action({ request, context }: Route.ActionArgs) {
     if (actionType === 'rsvp-dinner') {
         const response = oneOf<YesNoMaybe>(formData.get('rsvpSpeakersDinner'), YES_NO_MAYBE_OPTIONS)
         if (!response) return data({ error: 'Missing RSVP response' }, { status: 400 })
-        await services.speakers.saveSpeakerDinnerRsvp(targetSessionizeId, response, email)
+        const dietaryRequirements = emptyToUndefined(formData.get('dietaryRequirements'))
+        await services.speakers.saveSpeakerDinnerRsvp(targetSessionizeId, response, dietaryRequirements, email)
         return data({ dinnerRsvped: true })
     }
 
@@ -201,6 +202,7 @@ export default function AdminSpeakerPreview() {
                 dateLabel={view.dinnerDateLabel ?? ''}
                 calendarUrl={view.dinnerCalendarUrl ?? undefined}
                 currentResponse={view.dinnerResponse}
+                currentDietaryRequirements={view.dinnerDietaryRequirements}
                 justResponded={dinnerJustResponded}
             />
 

--- a/core/website/app/routes/speaker-portal._index.tsx
+++ b/core/website/app/routes/speaker-portal._index.tsx
@@ -12,7 +12,7 @@ import { SpeakerWorkspaceView } from '~/components/speaker-workspace-view'
 import { requireSpeaker } from '~/lib/auth.server'
 import { recordException } from '~/lib/record-exception'
 import { buildSpeakerDashboardView } from '~/lib/speakers/dashboard-view.server'
-import { parseMeetTheExpertsForm, parseSessionDetailsForm, parseSpeakerProfileForm } from '~/lib/speakers/profile-form.server'
+import { emptyToUndefined, parseMeetTheExpertsForm, parseSessionDetailsForm, parseSpeakerProfileForm } from '~/lib/speakers/profile-form.server'
 import { SPEAKER_TRAINING_SESSION_OPTIONS, YES_NO_MAYBE_OPTIONS, type SpeakerTrainingSession, type YesNoMaybe } from '~/lib/services/speakers-store'
 import { getServices } from '~/remix-app-load-context'
 import type { Route } from './+types/speaker-portal._index'
@@ -127,7 +127,8 @@ export async function action({ request, context }: Route.ActionArgs) {
         if (targetSessionizeId !== speaker.sessionizeId) throw new Response('Not Found', { status: 404 })
         const response = oneOf<YesNoMaybe>(formData.get('rsvpSpeakersDinner'), YES_NO_MAYBE_OPTIONS)
         if (!response) return data({ error: 'Missing RSVP response' }, { status: 400 })
-        await services.speakers.saveSpeakerDinnerRsvp(speaker.sessionizeId, response, user.email)
+        const dietaryRequirements = emptyToUndefined(formData.get('dietaryRequirements'))
+        await services.speakers.saveSpeakerDinnerRsvp(speaker.sessionizeId, response, dietaryRequirements, user.email)
         return data({ dinnerRsvped: true })
     }
 
@@ -194,6 +195,7 @@ export default function SpeakerPortalDashboard() {
                 dateLabel={view.dinnerDateLabel ?? ''}
                 calendarUrl={view.dinnerCalendarUrl ?? undefined}
                 currentResponse={view.dinnerResponse}
+                currentDietaryRequirements={view.dinnerDietaryRequirements}
                 justResponded={dinnerJustResponded}
             />
 

--- a/core/website/migrations/0015_speaker_sessionize_live_data.sql
+++ b/core/website/migrations/0015_speaker_sessionize_live_data.sql
@@ -1,0 +1,27 @@
+-- Speaker portal: stop duplicating Sessionize content into D1
+--
+-- speakers/speaker_sessions now hold IDs + linkage only. All Sessionize-
+-- sourced display content (name, bio, tagline, photo, links; session title,
+-- description, category values, schedule slot, room, status, confirmation)
+-- is read live from Sessionize at request time and merged with these rows
+-- by sessionize_id, instead of being copied in by the hourly sync. Nothing
+-- here held user-submitted data — it's all reproducible from the next sync
+-- — so a straight column drop is safe.
+
+ALTER TABLE speakers DROP COLUMN full_name;
+ALTER TABLE speakers DROP COLUMN tag_line;
+ALTER TABLE speakers DROP COLUMN bio;
+ALTER TABLE speakers DROP COLUMN profile_picture_url;
+ALTER TABLE speakers DROP COLUMN links_json;
+
+ALTER TABLE speaker_sessions DROP COLUMN session_title;
+ALTER TABLE speaker_sessions DROP COLUMN description;
+ALTER TABLE speaker_sessions DROP COLUMN format;
+ALTER TABLE speaker_sessions DROP COLUMN level;
+ALTER TABLE speaker_sessions DROP COLUMN general_topic;
+ALTER TABLE speaker_sessions DROP COLUMN talk_topics_json;
+ALTER TABLE speaker_sessions DROP COLUMN starts_at;
+ALTER TABLE speaker_sessions DROP COLUMN ends_at;
+ALTER TABLE speaker_sessions DROP COLUMN room_name;
+ALTER TABLE speaker_sessions DROP COLUMN status;
+ALTER TABLE speaker_sessions DROP COLUMN is_confirmed;


### PR DESCRIPTION
## Summary
- Dietary requirements are now asked as part of the speaker dinner RSVP (only relevant if attending) instead of the general session-details form.
- D1 speaker/session tables now hold only Sessionize ids + linkage; all Sessionize-sourced content (name, bio, session title, schedule, room, confirmation, etc.) is read live at request time and merged in by id, instead of being duplicated into D1 by the hourly sync. Portal-only data (RSVPs, dietary requirements, custom intros, etc.) still lives in D1 as before.
- CI: validate D1 migrations apply cleanly on every PR.

## Test plan
- [x] `pnpm nx typecheck website`
- [x] `pnpm nx test website` (280 passed, including updated `sync-plan.test.ts`)
- [x] `pnpm nx lint website`
- [x] `pnpm nx d1-migrate-local website` — new migration `0015_speaker_sessionize_live_data.sql` applies cleanly
- [x] Manually exercise `/speaker-portal`, `/admin/speakers`, `/admin/speakers/$sessionizeId` (dinner RSVP with dietary requirements, sync-now, checklist/RSVP flows) against local D1

🤖 Generated with [Claude Code](https://claude.com/claude-code)