### PR TITLE
Speaker portal: backup speaker acceptance, Excel contact import, Meet the Experts

### DIFF
--- a/conference/config/meet-the-experts.ts
+++ b/conference/config/meet-the-experts.ts
@@ -1,0 +1,20 @@
+import type { MeetTheExpertsConfig } from '@ddd/conference-config'
+
+/**
+ * Meet-the-Experts time blocks for DDD Perth — shared by the speaker portal
+ * (once a speaker opts in via the session-details form) and the sponsor
+ * portal (sponsors register straight in, no opt-in step).
+ *
+ * TODO: confirm exact Meet-the-Experts slot boundaries — placeholder six
+ * ~55-min blocks spanning the stated 10:30am-4pm window.
+ */
+export const meetTheExperts: MeetTheExpertsConfig = {
+    slots: [
+        { id: 'slot-1', label: '10:30am – 11:25am' },
+        { id: 'slot-2', label: '11:25am – 12:20pm' },
+        { id: 'slot-3', label: '12:20pm – 1:15pm' },
+        { id: 'slot-4', label: '1:15pm – 2:10pm' },
+        { id: 'slot-5', label: '2:10pm – 3:05pm' },
+        { id: 'slot-6', label: '3:05pm – 4:00pm' },
+    ],
+}

--- a/conference/config/speaker-portal.ts
+++ b/conference/config/speaker-portal.ts
@@ -52,16 +52,7 @@ export const speakerPortal: SpeakerPortalConfig = {
             dateTime: DateTime.fromISO('2026-10-02T18:00:00', { zone: 'Australia/Perth' }),
             endDateTime: DateTime.fromISO('2026-10-02T20:00:00', { zone: 'Australia/Perth' }),
         },
-        // TODO: confirm exact Meet-the-Experts slot boundaries — placeholder
-        // six ~55-min blocks spanning the stated 10:30am-4pm window.
-        meetTheExpertsSlots: [
-            { id: 'slot-1', label: '10:30am – 11:25am' },
-            { id: 'slot-2', label: '11:25am – 12:20pm' },
-            { id: 'slot-3', label: '12:20pm – 1:15pm' },
-            { id: 'slot-4', label: '1:15pm – 2:10pm' },
-            { id: 'slot-5', label: '2:10pm – 3:05pm' },
-            { id: 'slot-6', label: '3:05pm – 4:00pm' },
-        ],
     },
     sessionConfirmationNotifyEmail: 'speakers@dddperth.com',
+    speakerEmailAddress: 'speakers@dddperth.com',
 }

--- a/conference/manifest.ts
+++ b/conference/manifest.ts
@@ -13,6 +13,7 @@
  */
 
 import type { ConferenceManifest } from '@ddd/conference-config'
+import { meetTheExperts } from './config/meet-the-experts'
 import { nav } from './config/nav'
 import { conferenceConfigPublic } from './config/public'
 import { speakerPortal } from './config/speaker-portal'
@@ -49,4 +50,5 @@ export const conferenceManifest: ConferenceManifest = {
     },
     sponsorPortal,
     speakerPortal,
+    meetTheExperts,
 }

--- a/core/libs/conference-config/src/index.ts
+++ b/core/libs/conference-config/src/index.ts
@@ -30,6 +30,7 @@ export type {
     DeploymentConfig,
     HomepageContentSlots,
     MobileApp,
+    MeetTheExpertsConfig,
     MeetTheExpertsSlotConfig,
     NavConfig,
     NavItem,

--- a/core/libs/conference-config/src/manifest.ts
+++ b/core/libs/conference-config/src/manifest.ts
@@ -332,6 +332,17 @@ export interface SpeakerPortalConfig {
      * item either way.
      */
     sessionConfirmationNotifyEmail?: string
+    /**
+     * The speaker-facing team's shared inbox. Used two ways on the admin
+     * speakers list's follow-up items: as the destination for the "Send test
+     * email" button (sends the real template there instead of to actual
+     * speakers, so an admin can preview copy/rendering before a real send),
+     * and as the Reply-To on every follow-up email actually sent to
+     * speakers, so replies land with the team rather than the noreply
+     * From: address. Omit to hide the test-email button and skip setting
+     * Reply-To.
+     */
+    speakerEmailAddress?: string
 }
 
 /** One configured speaker-training session. `id` should match one of the
@@ -351,12 +362,6 @@ export interface SpeakerDinnerConfig {
     location?: string
 }
 
-/** One configured Meet-the-Experts time block. */
-export interface MeetTheExpertsSlotConfig {
-    id: string
-    label: string
-}
-
 export interface SpeakerPortalChecklistConfig {
     /** External link where a speaker claims/registers their complimentary ticket. */
     ticketClaimUrl?: string
@@ -367,9 +372,21 @@ export interface SpeakerPortalChecklistConfig {
     /** The speaker dinner — rendered in its own RSVP modal. Omit to hide the
      * checklist item entirely. */
     speakerDinner?: SpeakerDinnerConfig
-    /** Meet-the-Experts time blocks, shown as checkboxes in the session-
-     * details form once the speaker opts in (Yes/Maybe/Other). */
-    meetTheExpertsSlots?: MeetTheExpertsSlotConfig[]
+}
+
+/** One configured Meet-the-Experts time block. */
+export interface MeetTheExpertsSlotConfig {
+    id: string
+    label: string
+}
+
+/**
+ * Meet-the-Experts config — shared by the speaker and sponsor portals, since
+ * either a speaker or a sponsor can register a person for a time slot. Omit
+ * (or an empty `slots` array) to hide the feature in both portals.
+ */
+export interface MeetTheExpertsConfig {
+    slots: MeetTheExpertsSlotConfig[]
 }
 
 /**
@@ -394,6 +411,9 @@ export interface ConferenceManifest {
     sponsorPortal?: SponsorPortalConfig
     /** Speaker portal config. Omit for forks without one — /speaker-portal returns 404 then. */
     speakerPortal?: SpeakerPortalConfig
+    /** Meet-the-Experts time slots — shared by the speaker and sponsor
+     * portals. Omit to hide the feature entirely. */
+    meetTheExperts?: MeetTheExpertsConfig
 }
 
 /**

--- a/core/website/app/components/meet-the-experts-planner.tsx
+++ b/core/website/app/components/meet-the-experts-planner.tsx
@@ -1,0 +1,431 @@
+import { Fragment, useCallback, useRef, useState } from 'react'
+import { Button } from '~/components/ui/button'
+import { Box, Flex, styled } from '~/styled-system/jsx'
+
+/**
+ * Table x timeslot grid for seating Meet-the-Experts registrants.
+ *
+ * Timeslots are the configured `meetTheExperts.slots` from the conference
+ * manifest — the same list registrants already picked their preferences
+ * from — so every table column shares the exact same set of rows; unlike the
+ * agenda planner's per-track slot lists, there's no need to compute a max
+ * row count.
+ *
+ * Drag-and-drop follows the agenda planner's precedent: plain HTML5
+ * draggable/onDragStart/onDrop, no library. `onDragOver` only calls
+ * `preventDefault()` (accepting the drop) when the cell's slot is one of the
+ * dragged registrant's registered slots and they aren't already seated at a
+ * different table for that slot — everywhere else the browser's native
+ * "no-drop" cursor is the hard preference block, for free.
+ */
+
+export type MeetTheExpertsRegistrantType = 'speaker' | 'sponsor'
+
+export interface MeetTheExpertsSlotView {
+    id: string
+    label: string
+}
+
+export interface MeetTheExpertsTableView {
+    id: string
+    label: string
+    position: number
+}
+
+export interface MeetTheExpertsAssignmentView {
+    tableId: string
+    slotId: string
+    registrantType: MeetTheExpertsRegistrantType
+    registrantId: string
+    displayName: string
+}
+
+export interface MeetTheExpertsRegistrantView {
+    registrantType: MeetTheExpertsRegistrantType
+    registrantId: string
+    displayName: string
+    /** Slot ids this person registered as available for. */
+    slots: string[]
+    assignedCount: number
+}
+
+/** One board edit, mapped 1:1 onto the route's action intents. */
+export type MeetTheExpertsChange =
+    | { intent: 'add_table'; label: string }
+    | { intent: 'rename_table'; tableId: string; label: string }
+    | { intent: 'remove_table'; tableId: string }
+    | { intent: 'move_table'; tableId: string; direction: 'up' | 'down' }
+    | { intent: 'assign'; tableId: string; slotId: string; registrantType: string; registrantId: string }
+    | { intent: 'unassign'; tableId: string; slotId: string }
+
+function registrantKey(type: string, id: string): string {
+    return `${type}:${id}`
+}
+
+function cellKey(tableId: string, slotId: string): string {
+    return `${tableId}:${slotId}`
+}
+
+interface DraggingRegistrant {
+    type: MeetTheExpertsRegistrantType
+    id: string
+    displayName: string
+    slots: string[]
+    /** Slot ids this registrant already occupies at some table, so a drag
+     * over a different table for the same slot can be refused — they can't
+     * be seated in two places for the same slot. */
+    occupiedSlotIds: Set<string>
+}
+
+export function MeetTheExpertsPlanner({
+    slots,
+    tables,
+    assignments,
+    registrants,
+    onChange,
+}: {
+    slots: MeetTheExpertsSlotView[]
+    tables: MeetTheExpertsTableView[]
+    assignments: MeetTheExpertsAssignmentView[]
+    registrants: MeetTheExpertsRegistrantView[]
+    onChange: (change: MeetTheExpertsChange) => void
+}) {
+    const [draggingRegistrant, setDraggingRegistrant] = useState<DraggingRegistrant | null>(null)
+
+    // Table names are free-text inputs, so the local draft renders while
+    // being typed into — otherwise a revalidation landing mid-word would
+    // replace what's in the box with the server's older value. Same idiom as
+    // the agenda planner's draftNames.
+    const [draftNames, setDraftNames] = useState<Record<string, string>>({})
+    const debounceTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
+    const debouncedRename = useCallback(
+        (tableId: string, label: string) => {
+            clearTimeout(debounceTimers.current[tableId])
+            debounceTimers.current[tableId] = setTimeout(
+                () => onChange({ intent: 'rename_table', tableId, label }),
+                500,
+            )
+        },
+        [onChange],
+    )
+
+    const assignmentByCell = new Map(assignments.map((a) => [cellKey(a.tableId, a.slotId), a]))
+    const assignedSlotsByRegistrant = new Map<string, Set<string>>()
+    for (const a of assignments) {
+        const key = registrantKey(a.registrantType, a.registrantId)
+        const set = assignedSlotsByRegistrant.get(key) ?? new Set<string>()
+        set.add(a.slotId)
+        assignedSlotsByRegistrant.set(key, set)
+    }
+
+    function startDrag(registrant: MeetTheExpertsRegistrantView) {
+        setDraggingRegistrant({
+            type: registrant.registrantType,
+            id: registrant.registrantId,
+            displayName: registrant.displayName,
+            slots: registrant.slots,
+            occupiedSlotIds: assignedSlotsByRegistrant.get(
+                registrantKey(registrant.registrantType, registrant.registrantId),
+            ) ?? new Set(),
+        })
+    }
+
+    /** True when the currently-dragged registrant may be dropped on this cell. */
+    function canDropOn(tableId: string, slotId: string): boolean {
+        if (!draggingRegistrant) return false
+        if (!draggingRegistrant.slots.includes(slotId)) return false
+        const existing = assignmentByCell.get(cellKey(tableId, slotId))
+        const isSelf = existing?.registrantType === draggingRegistrant.type && existing.registrantId === draggingRegistrant.id
+        if (draggingRegistrant.occupiedSlotIds.has(slotId) && !isSelf) return false
+        return true
+    }
+
+    function addTable() {
+        onChange({ intent: 'add_table', label: `Table ${tables.length + 1}` })
+    }
+
+    function renameTable(tableId: string, label: string) {
+        setDraftNames((current) => ({ ...current, [tableId]: label }))
+        debouncedRename(tableId, label)
+    }
+
+    function removeTable(tableId: string, label: string) {
+        if (!confirm(`Remove "${label}"? Anyone seated at it will be unassigned.`)) return
+        onChange({ intent: 'remove_table', tableId })
+    }
+
+    function moveTable(tableId: string, direction: 'up' | 'down') {
+        onChange({ intent: 'move_table', tableId, direction })
+    }
+
+    function unassign(tableId: string, slotId: string) {
+        onChange({ intent: 'unassign', tableId, slotId })
+    }
+
+    function dropOnCell(tableId: string, slotId: string, e: React.DragEvent) {
+        e.preventDefault()
+        const [registrantType, registrantId] = (e.dataTransfer.getData('text/plain') || '').split(':')
+        setDraggingRegistrant(null)
+        if (!registrantType || !registrantId) return
+
+        const existing = assignmentByCell.get(cellKey(tableId, slotId))
+        if (existing && (existing.registrantType !== registrantType || existing.registrantId !== registrantId)) {
+            if (!confirm(`This seat holds ${existing.displayName}. Replace them?`)) return
+        }
+        onChange({ intent: 'assign', tableId, slotId, registrantType, registrantId })
+    }
+
+    return (
+        <Box>
+            <Flex gap="3" mb="4" flexWrap="wrap" alignItems="center">
+                <Button type="button" variant="solid" size="sm" onClick={addTable}>
+                    + Add table
+                </Button>
+                <styled.p fontSize="xs" color="admin.500">
+                    Drag a person from the list below onto a seat. Only their registered slots (and free tables) will
+                    accept the drop.
+                </styled.p>
+            </Flex>
+
+            {tables.length === 0 ? (
+                <styled.p fontSize="sm" color="admin.600" py="6" textAlign="center">
+                    No tables yet — add one to start seating people.
+                </styled.p>
+            ) : (
+                <Box overflowX="auto" pb="2">
+                    <styled.div
+                        display="grid"
+                        gap="2"
+                        alignItems="stretch"
+                        style={{
+                            gridTemplateColumns: `160px repeat(${tables.length}, 220px)`,
+                            gridTemplateRows: `auto repeat(${slots.length}, auto)`,
+                        }}
+                    >
+                        {/* Row 1: blank corner + one header per table. */}
+                        <Box style={{ gridColumn: 1, gridRow: 1 }} />
+                        {tables.map((table, tableIndex) => (
+                            <Flex
+                                key={`head-${table.id}`}
+                                justifyContent="space-between"
+                                alignItems="center"
+                                gap="1"
+                                style={{ gridColumn: tableIndex + 2, gridRow: 1 }}
+                                bg="admin.50"
+                                borderRadius="lg"
+                                px="2"
+                                py="1"
+                            >
+                                <styled.input
+                                    value={draftNames[table.id] ?? table.label}
+                                    onChange={(e) => renameTable(table.id, e.target.value)}
+                                    aria-label="Table name"
+                                    bg="transparent"
+                                    border="none"
+                                    fontWeight="semibold"
+                                    fontSize="sm"
+                                    width="full"
+                                    _hover={{ bg: 'white' }}
+                                    _focus={{ bg: 'white' }}
+                                    px="1"
+                                    borderRadius="sm"
+                                />
+                                <Flex gap="0.5" flexShrink="0">
+                                    <styled.button
+                                        type="button"
+                                        onClick={() => moveTable(table.id, 'up')}
+                                        disabled={tableIndex === 0}
+                                        title="Move table left"
+                                        aria-label="Move table left"
+                                        cursor={tableIndex === 0 ? 'not-allowed' : 'pointer'}
+                                        opacity={tableIndex === 0 ? '0.3' : '1'}
+                                        fontSize="xs"
+                                        px="0.5"
+                                    >
+                                        ←
+                                    </styled.button>
+                                    <styled.button
+                                        type="button"
+                                        onClick={() => moveTable(table.id, 'down')}
+                                        disabled={tableIndex === tables.length - 1}
+                                        title="Move table right"
+                                        aria-label="Move table right"
+                                        cursor={tableIndex === tables.length - 1 ? 'not-allowed' : 'pointer'}
+                                        opacity={tableIndex === tables.length - 1 ? '0.3' : '1'}
+                                        fontSize="xs"
+                                        px="0.5"
+                                    >
+                                        →
+                                    </styled.button>
+                                    <styled.button
+                                        type="button"
+                                        onClick={() => removeTable(table.id, table.label)}
+                                        title={`Remove ${table.label}`}
+                                        aria-label={`Remove ${table.label}`}
+                                        cursor="pointer"
+                                        color="admin.500"
+                                        fontSize="xs"
+                                        px="0.5"
+                                        _hover={{ color: 'status.danger.fg' }}
+                                    >
+                                        ×
+                                    </styled.button>
+                                </Flex>
+                            </Flex>
+                        ))}
+
+                        {/* Rows 2..N+1: one slot-label cell, then one seat cell per table. */}
+                        {slots.map((slot, slotIndex) => (
+                            <Fragment key={`row-${slot.id}`}>
+                                <Flex
+                                    key={`label-${slot.id}`}
+                                    style={{ gridColumn: 1, gridRow: slotIndex + 2 }}
+                                    alignItems="center"
+                                    fontSize="xs"
+                                    fontWeight="semibold"
+                                    color="admin.600"
+                                    px="1"
+                                >
+                                    {slot.label}
+                                </Flex>
+                                {tables.map((table, tableIndex) => {
+                                    const occupant = assignmentByCell.get(cellKey(table.id, slot.id))
+                                    const isValidTarget = canDropOn(table.id, slot.id)
+                                    return (
+                                        <Box
+                                            key={`cell-${table.id}-${slot.id}`}
+                                            style={{ gridColumn: tableIndex + 2, gridRow: slotIndex + 2 }}
+                                            bg={occupant ? 'white' : 'admin.50'}
+                                            border={
+                                                draggingRegistrant
+                                                    ? isValidTarget
+                                                        ? 'admin-emphasis'
+                                                        : 'admin-subtle'
+                                                    : 'admin-subtle'
+                                            }
+                                            opacity={draggingRegistrant && !isValidTarget && !occupant ? '0.5' : '1'}
+                                            borderRadius="md"
+                                            p="2"
+                                            minH="[52px]"
+                                            onDragOver={(e) => {
+                                                if (isValidTarget) e.preventDefault()
+                                            }}
+                                            onDrop={(e) => dropOnCell(table.id, slot.id, e)}
+                                        >
+                                            {occupant ? (
+                                                <Box>
+                                                    <styled.p fontSize="xs" fontWeight="medium" lineClamp={2}>
+                                                        {occupant.displayName}
+                                                    </styled.p>
+                                                    <styled.p fontSize="2xs" color="admin.500" mb="1">
+                                                        {occupant.registrantType === 'speaker' ? 'Speaker' : 'Sponsor'}
+                                                    </styled.p>
+                                                    <styled.button
+                                                        type="button"
+                                                        onClick={() => unassign(table.id, slot.id)}
+                                                        fontSize="2xs"
+                                                        color="prose.link"
+                                                        cursor="pointer"
+                                                        _hover={{ textDecoration: 'underline' }}
+                                                    >
+                                                        Unseat
+                                                    </styled.button>
+                                                </Box>
+                                            ) : (
+                                                <styled.p fontSize="2xs" color="admin.400" textAlign="center" mt="2">
+                                                    Empty seat
+                                                </styled.p>
+                                            )}
+                                        </Box>
+                                    )
+                                })}
+                            </Fragment>
+                        ))}
+                    </styled.div>
+                </Box>
+            )}
+
+            <Box mt="6">
+                <styled.h3 fontSize="md" fontWeight="semibold" mb="2" color="admin.600">
+                    Registered people ({registrants.length})
+                </styled.h3>
+                <styled.p fontSize="xs" color="admin.500" mb="2">
+                    Drag onto a seat above. Chips show the slots they registered as available; the count shows how
+                    many seats they currently hold — red means they aren't scheduled anywhere yet.
+                </styled.p>
+                <Flex gap="2" flexWrap="wrap" maxH="[280px]" overflowY="auto">
+                    {registrants.length === 0 ? (
+                        <styled.p fontSize="sm" color="admin.600">
+                            No one has registered a slot preference yet.
+                        </styled.p>
+                    ) : (
+                        registrants.map((registrant) => {
+                            const key = registrantKey(registrant.registrantType, registrant.registrantId)
+                            const isDragging =
+                                draggingRegistrant &&
+                                registrantKey(draggingRegistrant.type, draggingRegistrant.id) === key
+                            return (
+                                <Box
+                                    key={key}
+                                    draggable
+                                    onDragStart={(e) => {
+                                        e.dataTransfer.setData('text/plain', key)
+                                        startDrag(registrant)
+                                    }}
+                                    onDragEnd={() => setDraggingRegistrant(null)}
+                                    bg="white"
+                                    border="admin-subtle"
+                                    borderRadius="md"
+                                    px="2"
+                                    py="1"
+                                    maxW="[260px]"
+                                    cursor="grab"
+                                    opacity={isDragging ? '0.5' : '1'}
+                                >
+                                    <Flex justifyContent="space-between" alignItems="center" gap="1" mb="0.5">
+                                        <styled.p fontSize="xs" fontWeight="medium" lineClamp={1}>
+                                            {registrant.displayName}
+                                        </styled.p>
+                                        <styled.span
+                                            px="1.5"
+                                            py="0.5"
+                                            borderRadius="full"
+                                            fontSize="2xs"
+                                            fontWeight="bold"
+                                            bg={registrant.assignedCount === 0 ? 'status.danger.bg' : 'status.success.bg'}
+                                            color={registrant.assignedCount === 0 ? 'status.danger.fg' : 'status.success.fg'}
+                                            flexShrink="0"
+                                        >
+                                            {registrant.assignedCount}
+                                        </styled.span>
+                                    </Flex>
+                                    <styled.p fontSize="2xs" color="admin.500" mb="1">
+                                        {registrant.registrantType === 'speaker' ? 'Speaker' : 'Sponsor'}
+                                    </styled.p>
+                                    <Flex gap="1" flexWrap="wrap">
+                                        {registrant.slots.map((slotId) => {
+                                            const slot = slots.find((s) => s.id === slotId)
+                                            return (
+                                                <styled.span
+                                                    key={slotId}
+                                                    px="1"
+                                                    py="0.5"
+                                                    borderRadius="sm"
+                                                    fontSize="2xs"
+                                                    bg="admin.100"
+                                                    color="admin.700"
+                                                >
+                                                    {slot?.label ?? slotId}
+                                                </styled.span>
+                                            )
+                                        })}
+                                    </Flex>
+                                </Box>
+                            )
+                        })
+                    )}
+                </Flex>
+            </Box>
+        </Box>
+    )
+}

--- a/core/website/app/components/speaker-checklist-card.tsx
+++ b/core/website/app/components/speaker-checklist-card.tsx
@@ -72,11 +72,13 @@ function ChecklistActionButton({
     action,
     sessionizeId,
     ticketClaimUrl,
+    backupSessionIds,
     onOpenModal,
 }: {
     action: ChecklistItemAction
     sessionizeId: string
     ticketClaimUrl?: string
+    backupSessionIds: string[]
     onOpenModal: (key: ChecklistModalKey) => void
 }) {
     if ('kind' in action) {
@@ -84,6 +86,23 @@ function ChecklistActionButton({
             <button type="button" onClick={() => onOpenModal(action.modalKey)} className={actionLinkClass}>
                 {action.buttonLabel}
             </button>
+        )
+    }
+
+    // Session-level, not speaker-level — submits acceptance for every one of
+    // the viewer's own outstanding backup sessions at once (a dual-speaker
+    // session only needs one presenter to accept it; see markBackupAccepted).
+    if (action.action === 'accept-backup') {
+        return (
+            <Form method="post">
+                <input type="hidden" name="_action" value="accept-backup" />
+                {backupSessionIds.map((id) => (
+                    <input key={id} type="hidden" name="sessionizeSessionId" value={id} />
+                ))}
+                <button type="submit" className={claimButtonClass} disabled={backupSessionIds.length === 0}>
+                    {action.label}
+                </button>
+            </Form>
         )
     }
 
@@ -115,11 +134,13 @@ function ChecklistAction({
     item,
     sessionizeId,
     ticketClaimUrl,
+    backupSessionIds,
     onOpenModal,
 }: {
     item: SpeakerChecklistItem
     sessionizeId: string
     ticketClaimUrl?: string
+    backupSessionIds: string[]
     onOpenModal: (key: ChecklistModalKey) => void
 }) {
     if (item.done) return null
@@ -135,6 +156,7 @@ function ChecklistAction({
                     action={action}
                     sessionizeId={sessionizeId}
                     ticketClaimUrl={ticketClaimUrl}
+                    backupSessionIds={backupSessionIds}
                     onOpenModal={onOpenModal}
                 />
             ))}
@@ -153,12 +175,16 @@ export function SpeakerChecklistCard({
     sessionizeId,
     checklist,
     ticketClaimUrl,
+    backupSessionIds = [],
     onOpenModal,
     alwaysEditable = false,
 }: {
     sessionizeId: string
     checklist: SpeakerChecklistItem[]
     ticketClaimUrl?: string
+    /** The viewer's own sessions still needing backup-speaker acceptance —
+     * see `SpeakerDashboardView.backupSessionIds`. */
+    backupSessionIds?: string[]
     onOpenModal: (key: ChecklistModalKey) => void
     /** Lets a completed modal-based item be reopened even past its due
      * date — set by the admin preview, where an organiser acting on a
@@ -220,6 +246,7 @@ export function SpeakerChecklistCard({
                                     item={item}
                                     sessionizeId={sessionizeId}
                                     ticketClaimUrl={ticketClaimUrl}
+                                    backupSessionIds={backupSessionIds}
                                     onOpenModal={onOpenModal}
                                 />
                             </Flex>

--- a/core/website/app/components/sponsor-meet-the-experts-modal.tsx
+++ b/core/website/app/components/sponsor-meet-the-experts-modal.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react'
+import { Form, useNavigation } from 'react-router'
+import { SpeakerModal } from '~/components/speaker-modal'
+import { css } from '~/styled-system/css'
+import { Box, Flex, styled } from '~/styled-system/jsx'
+import type { MeetTheExpertsSlotView } from './speaker-meet-the-experts-modal'
+
+const checkboxRowClass = css({
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: '3',
+    fontSize: 'sm',
+    color: 'admin.800',
+    p: '3',
+    borderRadius: 'md',
+    bg: 'admin.100',
+})
+
+const inputClass = css({
+    mt: '1',
+    w: 'full',
+    px: '3',
+    py: '2',
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: 'admin.400',
+    borderRadius: 'md',
+    fontSize: 'sm',
+    bg: 'white',
+    color: 'admin.900',
+    _placeholder: { color: 'admin.400' },
+    _focus: { outline: 'none', borderColor: 'indigo.7', boxShadow: 'focus-ring' },
+})
+
+const readOnlyTextareaClass = css({
+    mt: '1',
+    w: 'full',
+    px: '3',
+    py: '2',
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: 'admin.300',
+    borderRadius: 'md',
+    fontSize: 'sm',
+    bg: 'admin.100',
+    color: 'admin.700',
+})
+
+const fieldLabelClass = css({
+    display: 'block',
+    fontSize: 'sm',
+    fontWeight: 'medium',
+    color: 'admin.700',
+})
+
+/**
+ * "Register for Meet the Experts" modal for the sponsor portal — same
+ * structure as `SpeakerMeetTheExpertsModal` (checkbox list of configured
+ * slots + a bio toggle), submitting to `save-meet-the-experts` on
+ * `/portal`. One registration per sponsor (company-level), unlike speakers
+ * there's no preliminary opt-in question — a sponsor goes straight to
+ * registering. The bio default is the sponsor's own submitted company blurb
+ * rather than a Sessionize bio.
+ */
+export function SponsorMeetTheExpertsModal({
+    open,
+    onOpenChange,
+    issueKey,
+    slots,
+    selectedSlotIds,
+    hasResponded,
+    justResponded,
+    blurb,
+    bioUseDefault,
+    bioCustomText,
+}: {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    issueKey: string
+    slots: MeetTheExpertsSlotView[]
+    selectedSlotIds: string[]
+    hasResponded: boolean
+    justResponded: boolean
+    /** The sponsor's submitted company blurb — prefills the read-only "use
+     * our company blurb" view. */
+    blurb?: string
+    bioUseDefault: boolean
+    bioCustomText?: string
+}) {
+    const navigation = useNavigation()
+    const isSubmitting =
+        navigation.state === 'submitting' && navigation.formData?.get('_action') === 'save-meet-the-experts'
+
+    const [editingBio, setEditingBio] = useState(!bioUseDefault)
+
+    return (
+        <SpeakerModal title="Meet the Experts" open={open} onOpenChange={onOpenChange}>
+            <styled.p fontSize="sm" color="admin.600" mb="4">
+                Select every time slot your team can make — it's fine to leave them all unchecked if none of them
+                work for you.
+            </styled.p>
+
+            {justResponded && (
+                <Box role="status" mb="4" p="3" bg="status.success.bg" borderRadius="md" fontSize="sm" color="status.success.fg">
+                    Saved — thank you!
+                </Box>
+            )}
+
+            {slots.length === 0 ? (
+                <styled.p fontSize="sm" color="admin.600">
+                    No Meet the Experts time slots have been announced yet.
+                </styled.p>
+            ) : (
+                <Form method="post">
+                    <input type="hidden" name="_action" value="save-meet-the-experts" />
+                    <input type="hidden" name="targetIssueKey" value={issueKey} />
+                    <Flex direction="column" gap="2" mb="5">
+                        {slots.map((slot) => (
+                            <label key={slot.id} htmlFor={`meetExpertsSlot-${slot.id}`} className={checkboxRowClass}>
+                                <input
+                                    id={`meetExpertsSlot-${slot.id}`}
+                                    type="checkbox"
+                                    name="registerMeetTheExpertsSlots"
+                                    value={slot.id}
+                                    defaultChecked={selectedSlotIds.includes(slot.id)}
+                                />
+                                <styled.span>{slot.label}</styled.span>
+                            </label>
+                        ))}
+                    </Flex>
+
+                    <Box mb="5">
+                        <styled.span display="block" className={fieldLabelClass} mb="2">
+                            Bio/description
+                        </styled.span>
+                        <input
+                            type="hidden"
+                            name="meetTheExpertsBioSource"
+                            value={editingBio ? 'custom' : 'default'}
+                        />
+                        {editingBio ? (
+                            <textarea
+                                name="meetTheExpertsBioCustomText"
+                                rows={4}
+                                defaultValue={bioCustomText ?? blurb ?? ''}
+                                placeholder="What should attendees know about your team for a Meet the Experts chat?"
+                                className={inputClass}
+                            />
+                        ) : (
+                            <>
+                                <textarea readOnly rows={4} value={blurb ?? ''} className={readOnlyTextareaClass} />
+                                <Flex align="center" justify="space-between" mt="2" gap="3">
+                                    <styled.p fontSize="xs" color="admin.600">
+                                        Just use our company blurb.
+                                    </styled.p>
+                                    <styled.button
+                                        type="button"
+                                        onClick={() => setEditingBio(true)}
+                                        fontSize="xs"
+                                        fontWeight="medium"
+                                        color="admin.900"
+                                        textDecoration="underline"
+                                        bg="transparent"
+                                        border="none"
+                                        cursor="pointer"
+                                        flexShrink="0"
+                                    >
+                                        Edit bio
+                                    </styled.button>
+                                </Flex>
+                            </>
+                        )}
+                    </Box>
+
+                    <Flex justify="flex-end">
+                        <styled.button
+                            type="submit"
+                            disabled={isSubmitting}
+                            bg="admin.900"
+                            color="white"
+                            border="none"
+                            py="2.5"
+                            px="6"
+                            borderRadius="md"
+                            fontSize="sm"
+                            fontWeight="semibold"
+                            cursor="pointer"
+                            _hover={{ bg: 'admin.800' }}
+                            _disabled={{ bg: 'admin.400', cursor: 'not-allowed', opacity: 0.8 }}
+                        >
+                            {isSubmitting ? 'Saving…' : hasResponded ? 'Update' : 'Save'}
+                        </styled.button>
+                    </Flex>
+                </Form>
+            )}
+        </SpeakerModal>
+    )
+}

--- a/core/website/app/lib/services/app-services.ts
+++ b/core/website/app/lib/services/app-services.ts
@@ -4,6 +4,8 @@ import type { AssetStorage } from './asset-storage'
 import type { AuthService } from './auth-service'
 import type { ContentService } from './content-service'
 import type { EmailService } from './email-service'
+import type { MeetTheExpertsSchedulingStore } from './meet-the-experts-scheduling-store'
+import type { MeetTheExpertsStore } from './meet-the-experts-store'
 import type { NotificationLog } from './notification-log'
 import type { SessionStorages } from './session-storages'
 import type { SpeakerSyncService } from './speaker-sync-service'
@@ -35,4 +37,6 @@ export interface AppServices {
     notifications: NotificationLog
     speakers: SpeakersStore
     speakerSync: SpeakerSyncService
+    meetTheExperts: MeetTheExpertsStore
+    meetTheExpertsScheduling: MeetTheExpertsSchedulingStore
 }

--- a/core/website/app/lib/services/cloudflare/build-services.server.ts
+++ b/core/website/app/lib/services/cloudflare/build-services.server.ts
@@ -6,6 +6,8 @@ import { createCookieSessionStorages } from './cookie-session-storages.server'
 import { createD1AgendaPlanningStore } from './d1-agenda-planning-store.server'
 import { createD1AnnouncementsStore } from './d1-announcements-store.server'
 import { createD1AuthService } from './d1-auth-service.server'
+import { createD1MeetTheExpertsSchedulingStore } from './d1-meet-the-experts-scheduling-store.server'
+import { createD1MeetTheExpertsStore } from './d1-meet-the-experts-store.server'
 import { createD1NotificationLog } from './d1-notification-log.server'
 import { createD1SpeakersStore } from './d1-speakers-store.server'
 import { createD1SponsorsStore } from './d1-sponsors-store.server'
@@ -35,6 +37,7 @@ export function buildCloudflareServices(config: AppConfig, env: CloudflareEnv): 
     const speakers = createD1SpeakersStore({ db, config })
     const notifications = createD1NotificationLog(db)
     const assets = createR2AssetStorage(env.SPONSOR_ASSETS)
+    const meetTheExperts = createD1MeetTheExpertsStore(db)
 
     return {
         voting: createD1VotingStore(db),
@@ -51,5 +54,7 @@ export function buildCloudflareServices(config: AppConfig, env: CloudflareEnv): 
         notifications,
         speakers,
         speakerSync: createSessionizeSpeakerSyncService({ config, speakers }),
+        meetTheExperts,
+        meetTheExpertsScheduling: createD1MeetTheExpertsSchedulingStore(db, meetTheExperts),
     }
 }

--- a/core/website/app/lib/services/cloudflare/d1-meet-the-experts-scheduling-store.server.ts
+++ b/core/website/app/lib/services/cloudflare/d1-meet-the-experts-scheduling-store.server.ts
@@ -1,0 +1,163 @@
+import type { MeetTheExpertsStore } from '../meet-the-experts-store'
+import type {
+    MeetTheExpertsAssignment,
+    MeetTheExpertsSchedulingStore,
+    MeetTheExpertsTable,
+} from '../meet-the-experts-scheduling-store'
+
+interface TableRow {
+    id: string
+    label: string
+    position: number
+}
+
+interface AssignmentRow {
+    table_id: string
+    slot_id: string
+    registrant_type: string
+    registrant_id: string
+    assigned_at: number
+    assigned_by: string
+}
+
+function toTable(row: TableRow): MeetTheExpertsTable {
+    return { id: row.id, label: row.label, position: row.position }
+}
+
+function toAssignment(row: AssignmentRow): MeetTheExpertsAssignment {
+    return {
+        tableId: row.table_id,
+        slotId: row.slot_id,
+        registrantType: row.registrant_type as MeetTheExpertsAssignment['registrantType'],
+        registrantId: row.registrant_id,
+        assignedAt: row.assigned_at,
+        assignedBy: row.assigned_by,
+    }
+}
+
+/**
+ * `meetTheExperts` is the registration store, injected so `assign` can check
+ * a registrant's chosen slots before seating them — the server-side half of
+ * the hard preference block (the client already refuses to start a drop
+ * outside a registrant's slots, but the server is the authority).
+ */
+export function createD1MeetTheExpertsSchedulingStore(
+    db: D1Database,
+    meetTheExperts: MeetTheExpertsStore,
+): MeetTheExpertsSchedulingStore {
+    return {
+        async getState() {
+            const [tables, assignments] = await db.batch<TableRow | AssignmentRow>([
+                db.prepare(`SELECT id, label, position FROM meet_the_experts_tables ORDER BY position`),
+                db.prepare(`SELECT * FROM meet_the_experts_assignments`),
+            ])
+            return {
+                tables: tables.results.map((row) => toTable(row as TableRow)),
+                assignments: assignments.results.map((row) => toAssignment(row as AssignmentRow)),
+            }
+        },
+
+        async addTable(label) {
+            const id = crypto.randomUUID()
+            const now = Math.floor(Date.now() / 1000)
+            await db
+                .prepare(
+                    `INSERT INTO meet_the_experts_tables (id, label, position, created_at, updated_at)
+                     VALUES (?, ?, (SELECT COALESCE(MAX(position), -1) + 1 FROM meet_the_experts_tables), ?, ?)`,
+                )
+                .bind(id, label, now, now)
+                .run()
+            const row = await db
+                .prepare(`SELECT id, label, position FROM meet_the_experts_tables WHERE id = ?`)
+                .bind(id)
+                .first<TableRow>()
+            if (!row) throw new Error('Table vanished immediately after being created')
+            return toTable(row)
+        },
+
+        async renameTable(tableId, label) {
+            await db
+                .prepare(`UPDATE meet_the_experts_tables SET label = ?, updated_at = ? WHERE id = ?`)
+                .bind(label, Math.floor(Date.now() / 1000), tableId)
+                .run()
+        },
+
+        async removeTable(tableId) {
+            // Delete assignments explicitly rather than relying on the FK's
+            // ON DELETE CASCADE — D1 doesn't enable foreign_keys on every
+            // connection, same caveat as the agenda planner's removeTrack.
+            await db.batch([
+                db.prepare(`DELETE FROM meet_the_experts_assignments WHERE table_id = ?`).bind(tableId),
+                db.prepare(`DELETE FROM meet_the_experts_tables WHERE id = ?`).bind(tableId),
+            ])
+        },
+
+        async moveTable(tableId, direction) {
+            const current = await db
+                .prepare(`SELECT position FROM meet_the_experts_tables WHERE id = ?`)
+                .bind(tableId)
+                .first<{ position: number }>()
+            if (!current) return
+
+            const neighbour = await db
+                .prepare(
+                    direction === 'up'
+                        ? `SELECT id, position FROM meet_the_experts_tables WHERE position < ? ORDER BY position DESC LIMIT 1`
+                        : `SELECT id, position FROM meet_the_experts_tables WHERE position > ? ORDER BY position ASC LIMIT 1`,
+                )
+                .bind(current.position)
+                .first<{ id: string; position: number }>()
+            // Already at the start/end of the table list.
+            if (!neighbour) return
+
+            const now = Math.floor(Date.now() / 1000)
+            await db.batch([
+                db
+                    .prepare(`UPDATE meet_the_experts_tables SET position = ?, updated_at = ? WHERE id = ?`)
+                    .bind(neighbour.position, now, tableId),
+                db
+                    .prepare(`UPDATE meet_the_experts_tables SET position = ?, updated_at = ? WHERE id = ?`)
+                    .bind(current.position, now, neighbour.id),
+            ])
+        },
+
+        async assign(tableId, slotId, registrant, assignedBy) {
+            const registration = await meetTheExperts.getRegistration(registrant.type, registrant.id)
+            if (!registration || !registration.slots.includes(slotId)) {
+                throw new Error("That person didn't register this slot as one they're available for.")
+            }
+
+            const elsewhere = await db
+                .prepare(
+                    `SELECT table_id FROM meet_the_experts_assignments
+                     WHERE slot_id = ? AND registrant_type = ? AND registrant_id = ? AND table_id != ?`,
+                )
+                .bind(slotId, registrant.type, registrant.id, tableId)
+                .first<{ table_id: string }>()
+            if (elsewhere) {
+                throw new Error('That person is already seated at another table for this slot.')
+            }
+
+            await db
+                .prepare(
+                    `INSERT INTO meet_the_experts_assignments
+                         (table_id, slot_id, registrant_type, registrant_id, assigned_at, assigned_by)
+                     VALUES (?, ?, ?, ?, unixepoch(), ?)
+                     ON CONFLICT(table_id, slot_id) DO UPDATE SET
+                         registrant_type = excluded.registrant_type,
+                         registrant_id = excluded.registrant_id,
+                         assigned_at = excluded.assigned_at,
+                         assigned_by = excluded.assigned_by`,
+                )
+                .bind(tableId, slotId, registrant.type, registrant.id, assignedBy)
+                .run()
+        },
+
+        async unassign(tableId, slotId) {
+            await db
+                .prepare(`DELETE FROM meet_the_experts_assignments WHERE table_id = ? AND slot_id = ?`)
+                .bind(tableId, slotId)
+                .run()
+        },
+    }
+}

--- a/core/website/app/lib/services/cloudflare/d1-meet-the-experts-store.server.ts
+++ b/core/website/app/lib/services/cloudflare/d1-meet-the-experts-store.server.ts
@@ -1,0 +1,84 @@
+import type { MeetTheExpertsRegistration, MeetTheExpertsRegistrantType, MeetTheExpertsStore } from '../meet-the-experts-store'
+
+interface MeetTheExpertsRegistrationRow {
+    registrant_type: string
+    registrant_id: string
+    slots_json: string | null
+    bio_use_default: number
+    bio_custom_text: string | null
+    responded_at: number
+    updated_at: number
+    updated_by: string
+}
+
+/** Parses a JSON array column, tolerating null/corrupt values so a bad row
+ * can't take the whole dashboard down. Duplicated from d1-speakers-store's
+ * helper of the same name rather than shared — both are tiny and each store
+ * stays independently readable. */
+function parseJsonArray(json: string | null): string[] {
+    if (!json) return []
+    try {
+        const value: unknown = JSON.parse(json)
+        return Array.isArray(value) ? (value as string[]) : []
+    } catch {
+        return []
+    }
+}
+
+function toRegistration(row: MeetTheExpertsRegistrationRow): MeetTheExpertsRegistration {
+    return {
+        registrantType: row.registrant_type as MeetTheExpertsRegistrantType,
+        registrantId: row.registrant_id,
+        slots: parseJsonArray(row.slots_json),
+        bioUseDefault: row.bio_use_default === 1,
+        bioCustomText: row.bio_custom_text ?? undefined,
+        respondedAt: row.responded_at,
+        updatedAt: row.updated_at,
+        updatedBy: row.updated_by,
+    }
+}
+
+export function createD1MeetTheExpertsStore(db: D1Database): MeetTheExpertsStore {
+    return {
+        async getRegistration(registrantType, registrantId) {
+            const row = await db
+                .prepare(`SELECT * FROM meet_the_experts_registrations WHERE registrant_type = ? AND registrant_id = ?`)
+                .bind(registrantType, registrantId)
+                .first<MeetTheExpertsRegistrationRow>()
+            return row ? toRegistration(row) : null
+        },
+
+        async listRegistrations() {
+            const { results } = await db
+                .prepare(`SELECT * FROM meet_the_experts_registrations`)
+                .all<MeetTheExpertsRegistrationRow>()
+            return results.map(toRegistration)
+        },
+
+        async saveRegistration(registrantType, registrantId, details, updatedBy) {
+            await db
+                .prepare(
+                    `INSERT INTO meet_the_experts_registrations
+                         (registrant_type, registrant_id, slots_json, bio_use_default, bio_custom_text,
+                          responded_at, updated_at, updated_by)
+                     VALUES (?, ?, ?, ?, ?, unixepoch(), unixepoch(), ?)
+                     ON CONFLICT(registrant_type, registrant_id) DO UPDATE SET
+                         slots_json = excluded.slots_json,
+                         bio_use_default = excluded.bio_use_default,
+                         bio_custom_text = excluded.bio_custom_text,
+                         responded_at = excluded.responded_at,
+                         updated_at = excluded.updated_at,
+                         updated_by = excluded.updated_by`,
+                )
+                .bind(
+                    registrantType,
+                    registrantId,
+                    details.slots.length > 0 ? JSON.stringify(details.slots) : null,
+                    details.bioUseDefault ? 1 : 0,
+                    details.bioCustomText ?? null,
+                    updatedBy,
+                )
+                .run()
+        },
+    }
+}

--- a/core/website/app/lib/services/cloudflare/d1-speakers-store.server.ts
+++ b/core/website/app/lib/services/cloudflare/d1-speakers-store.server.ts
@@ -59,10 +59,6 @@ interface SpeakerProfileRow {
     rsvp_speaker_training_responded_at: number | null
     register_meet_the_experts: string | null
     register_meet_the_experts_other: string | null
-    register_meet_the_experts_slots_json: string | null
-    register_meet_the_experts_responded_at: number | null
-    meet_the_experts_bio_use_sessionize_bio: number
-    meet_the_experts_bio_custom_text: string | null
     completed_at: number | null
     updated_at: number
     updated_by: string
@@ -118,7 +114,7 @@ function toSpeaker(row: SpeakerRow, content: PortalSpeakerContent): SpeakerRecor
     }
 }
 
-function toSession(row: SpeakerSessionRow, content: PortalSessionContent): SpeakerSession {
+function toSession(row: SpeakerSessionRow, content: PortalSessionContent, foundInSessionize: boolean): SpeakerSession {
     return {
         sessionizeSessionId: row.sessionize_session_id,
         sessionTitle: content.sessionTitle,
@@ -132,6 +128,7 @@ function toSession(row: SpeakerSessionRow, content: PortalSessionContent): Speak
         roomName: content.roomName,
         status: content.status,
         isConfirmed: content.isConfirmed,
+        foundInSessionize,
     }
 }
 
@@ -177,10 +174,6 @@ function toProfile(row: SpeakerProfileRow): SpeakerProfile {
         rsvpSpeakerTrainingRespondedAt: row.rsvp_speaker_training_responded_at ?? undefined,
         registerMeetTheExperts: (row.register_meet_the_experts as YesNoMaybeOther | null) ?? undefined,
         registerMeetTheExpertsOther: row.register_meet_the_experts_other ?? undefined,
-        registerMeetTheExpertsSlots: parseJsonArray(row.register_meet_the_experts_slots_json),
-        registerMeetTheExpertsRespondedAt: row.register_meet_the_experts_responded_at ?? undefined,
-        meetTheExpertsBioUseSessionizeBio: row.meet_the_experts_bio_use_sessionize_bio === 1,
-        meetTheExpertsBioCustomText: row.meet_the_experts_bio_custom_text ?? undefined,
         completedAt: row.completed_at ?? undefined,
         updatedAt: row.updated_at,
         updatedBy: row.updated_by,
@@ -367,13 +360,20 @@ export function createD1SpeakersStore(args: { db: D1Database; config: AppConfig 
                     })),
                 )
 
+                const backupAcceptanceRow = await db
+                    .prepare(`SELECT 1 FROM session_backup_acceptance WHERE sessionize_session_id = ?`)
+                    .bind(sessionRow.sessionize_session_id)
+                    .first()
+
                 workspace.sessions.push({
                     session: toSession(
                         sessionRow,
                         live.sessions.get(sessionRow.sessionize_session_id) ??
                             placeholderSession(sessionRow.sessionize_session_id),
+                        live.sessions.has(sessionRow.sessionize_session_id),
                     ),
                     sessionDetails: await this.getSessionDetails(sessionRow.sessionize_session_id),
+                    backupAccepted: backupAcceptanceRow !== null,
                     presenters,
                 })
             }
@@ -382,7 +382,16 @@ export function createD1SpeakersStore(args: { db: D1Database; config: AppConfig 
         },
 
         async listSpeakers(year) {
-            const [speakersResult, contacts, sessions, profiles, sessionDetailsRows, live] = await Promise.all([
+            const [
+                speakersResult,
+                contacts,
+                sessions,
+                profiles,
+                sessionDetailsRows,
+                meetTheExpertsRows,
+                backupAcceptanceRows,
+                live,
+            ] = await Promise.all([
                 db.prepare(`SELECT * FROM speakers WHERE year = ?`).bind(year).all<SpeakerRow>(),
                 db
                     .prepare(
@@ -414,6 +423,22 @@ export function createD1SpeakersStore(args: { db: D1Database; config: AppConfig 
                     )
                     .bind(year)
                     .all<{ sessionize_session_id: string; questions_preference: string | null }>(),
+                db
+                    .prepare(
+                        `SELECT m.registrant_id FROM meet_the_experts_registrations m
+                         JOIN speakers s ON s.sessionize_id = m.registrant_id
+                         WHERE m.registrant_type = 'speaker' AND s.year = ?`,
+                    )
+                    .bind(year)
+                    .all<{ registrant_id: string }>(),
+                db
+                    .prepare(
+                        `SELECT sba.sessionize_session_id FROM session_backup_acceptance sba
+                         JOIN speaker_sessions ss ON ss.sessionize_session_id = sba.sessionize_session_id
+                         JOIN speakers s ON s.sessionize_id = ss.sessionize_speaker_id WHERE s.year = ?`,
+                    )
+                    .bind(year)
+                    .all<{ sessionize_session_id: string }>(),
                 fetchLiveContent(config),
             ])
 
@@ -426,13 +451,21 @@ export function createD1SpeakersStore(args: { db: D1Database; config: AppConfig 
             const sessionsBySpeaker = new Map<string, SpeakerSession[]>()
             for (const s of sessions.results ?? []) {
                 const list = sessionsBySpeaker.get(s.sessionize_speaker_id) ?? []
-                list.push(toSession(s, live.sessions.get(s.sessionize_session_id) ?? placeholderSession(s.sessionize_session_id)))
+                list.push(
+                    toSession(
+                        s,
+                        live.sessions.get(s.sessionize_session_id) ?? placeholderSession(s.sessionize_session_id),
+                        live.sessions.has(s.sessionize_session_id),
+                    ),
+                )
                 sessionsBySpeaker.set(s.sessionize_speaker_id, list)
             }
             const profileBySpeaker = new Map((profiles.results ?? []).map((p) => [p.sessionize_id, toProfile(p)]))
             const sessionDetailsCompleteById = new Map(
                 (sessionDetailsRows.results ?? []).map((r) => [r.sessionize_session_id, Boolean(r.questions_preference)]),
             )
+            const meetTheExpertsRespondedBySpeaker = new Set((meetTheExpertsRows.results ?? []).map((r) => r.registrant_id))
+            const backupAcceptedSessionIds = new Set((backupAcceptanceRows.results ?? []).map((r) => r.sessionize_session_id))
 
             const entries = (speakersResult.results ?? []).map((row): SpeakerListEntry => {
                 const speakerSessions = sessionsBySpeaker.get(row.sessionize_id) ?? []
@@ -446,6 +479,10 @@ export function createD1SpeakersStore(args: { db: D1Database; config: AppConfig 
                             s.sessionizeSessionId,
                             sessionDetailsCompleteById.get(s.sessionizeSessionId) ?? false,
                         ]),
+                    ),
+                    meetTheExpertsResponded: meetTheExpertsRespondedBySpeaker.has(row.sessionize_id),
+                    sessionBackupAccepted: Object.fromEntries(
+                        speakerSessions.map((s) => [s.sessionizeSessionId, backupAcceptedSessionIds.has(s.sessionizeSessionId)]),
                     ),
                 }
             })
@@ -476,11 +513,12 @@ export function createD1SpeakersStore(args: { db: D1Database; config: AppConfig 
 
         async saveProfile(sessionizeId, details, updatedBy) {
             // Deliberately doesn't touch dietary_requirements / rsvp_speakers_dinner /
-            // rsvp_speaker_training_json / rsvp_speaker_training_responded_at /
-            // register_meet_the_experts_slots_json / register_meet_the_experts_responded_at
-            // — those are owned by saveSpeakerDinnerRsvp / saveSpeakerTrainingRsvp /
-            // saveMeetTheExpertsSlots now, so a session-details save can never
-            // clobber an RSVP already on file.
+            // rsvp_speaker_training_json / rsvp_speaker_training_responded_at
+            // — those are owned by saveSpeakerDinnerRsvp / saveSpeakerTrainingRsvp
+            // now, so a session-details save can never clobber an RSVP already
+            // on file. Meet-the-Experts registration lives in
+            // meet_the_experts_registrations, a separate table entirely — see
+            // services.meetTheExperts.
             await db
                 .prepare(
                     `INSERT INTO speaker_profiles
@@ -535,31 +573,6 @@ export function createD1SpeakersStore(args: { db: D1Database; config: AppConfig 
                     details.presentationDetailsOther ?? null,
                     details.optOutOfRecording ? 1 : 0,
                     details.anythingElse ?? null,
-                    updatedBy,
-                )
-                .run()
-        },
-
-        async saveMeetTheExpertsSlots(sessionizeId, details, updatedBy) {
-            await db
-                .prepare(
-                    `INSERT INTO speaker_profiles
-                         (sessionize_id, register_meet_the_experts_slots_json,
-                          register_meet_the_experts_responded_at,
-                          meet_the_experts_bio_use_sessionize_bio, meet_the_experts_bio_custom_text,
-                          updated_at, updated_by)
-                     VALUES (?, ?, unixepoch(), ?, ?, unixepoch(), ?)
-                     ON CONFLICT(sessionize_id) DO UPDATE SET
-                         register_meet_the_experts_slots_json = excluded.register_meet_the_experts_slots_json,
-                         register_meet_the_experts_responded_at = excluded.register_meet_the_experts_responded_at,
-                         meet_the_experts_bio_use_sessionize_bio = excluded.meet_the_experts_bio_use_sessionize_bio,
-                         meet_the_experts_bio_custom_text = excluded.meet_the_experts_bio_custom_text`,
-                )
-                .bind(
-                    sessionizeId,
-                    details.slots.length > 0 ? JSON.stringify(details.slots) : null,
-                    details.bioUseSessionizeBio ? 1 : 0,
-                    details.bioCustomText ?? null,
                     updatedBy,
                 )
                 .run()
@@ -644,6 +657,21 @@ export function createD1SpeakersStore(args: { db: D1Database; config: AppConfig 
                 .bind(sessionizeId, updatedBy)
                 .run()
             return true
+        },
+
+        async markBackupAccepted(sessionizeSessionId, updatedBy) {
+            // Session-level, not speaker-level — set once per session, never
+            // unset, so a dual-speaker session only needs one presenter to
+            // accept it. DO NOTHING on conflict since there's nothing else
+            // on the row to update; the first acceptance wins.
+            await db
+                .prepare(
+                    `INSERT INTO session_backup_acceptance (sessionize_session_id, accepted_at, accepted_by)
+                     VALUES (?, unixepoch(), ?)
+                     ON CONFLICT(sessionize_session_id) DO NOTHING`,
+                )
+                .bind(sessionizeSessionId, updatedBy)
+                .run()
         },
 
         async applySyncPlan(plan) {

--- a/core/website/app/lib/services/cloudflare/resend-email-service.server.ts
+++ b/core/website/app/lib/services/cloudflare/resend-email-service.server.ts
@@ -23,6 +23,7 @@ export function createResendEmailService(args: { apiKey: string; defaultFrom: st
             const result = await resend.emails.send({
                 from: message.from ?? args.defaultFrom,
                 to: message.to,
+                replyTo: message.replyTo,
                 subject: message.subject,
                 html: message.html,
                 text: message.text,

--- a/core/website/app/lib/services/console-email-service.server.ts
+++ b/core/website/app/lib/services/console-email-service.server.ts
@@ -15,6 +15,7 @@ export function createConsoleEmailService(): EmailService {
         async send(message: EmailMessage) {
             console.log('\n=== Email (no provider configured) ===')
             console.log(`To:      ${message.to}`)
+            if (message.replyTo) console.log(`Reply-To: ${message.replyTo}`)
             console.log(`Subject: ${message.subject}`)
             console.log('---')
             console.log(message.text)

--- a/core/website/app/lib/services/email-service.ts
+++ b/core/website/app/lib/services/email-service.ts
@@ -22,6 +22,8 @@ export interface EmailMessage {
     text: string
     /** Per-message override of the configured from-address (rare; keep undefined for normal use). */
     from?: string
+    /** Reply-To address, e.g. a team inbox so replies don't land at a noreply From:. */
+    replyTo?: string
     /**
      * Attachments are part of the surface so future calendar-invite and
      * ticket-confirmation flows don't require an interface change.

--- a/core/website/app/lib/services/meet-the-experts-scheduling-store.ts
+++ b/core/website/app/lib/services/meet-the-experts-scheduling-store.ts
@@ -1,0 +1,58 @@
+import type { MeetTheExpertsRegistrantType } from './meet-the-experts-store'
+
+/**
+ * Admin-created seat for Meet the Experts. Timeslots aren't a table here —
+ * the grid's rows are the configured `meetTheExperts.slots` from the
+ * conference manifest, the same list registrants already picked their
+ * preferences from. Only the tables (columns) and the assignment of a
+ * registrant to a (table, slot) cell are admin-managed state.
+ */
+export interface MeetTheExpertsTable {
+    id: string
+    label: string
+    position: number
+}
+
+export interface MeetTheExpertsAssignment {
+    tableId: string
+    slotId: string
+    registrantType: MeetTheExpertsRegistrantType
+    registrantId: string
+    assignedAt: number
+    assignedBy: string
+}
+
+export interface MeetTheExpertsSchedulingState {
+    tables: MeetTheExpertsTable[]
+    assignments: MeetTheExpertsAssignment[]
+}
+
+export interface MeetTheExpertsSchedulingStore {
+    getState(): Promise<MeetTheExpertsSchedulingState>
+
+    /** Appends a table after whatever's already there. */
+    addTable(label: string): Promise<MeetTheExpertsTable>
+    renameTable(tableId: string, label: string): Promise<void>
+    /** Cascades: any assignments seated at this table are removed with it. */
+    removeTable(tableId: string): Promise<void>
+    /** Swaps position with the nearest table in that direction. No-op at
+     * either end of the table list. */
+    moveTable(tableId: string, direction: 'up' | 'down'): Promise<void>
+
+    /**
+     * Seats a registrant at (tableId, slotId), bumping whoever was there
+     * before. Throws if `slotId` isn't one of the registrant's registered
+     * slots, or if they're already seated at a *different* table for
+     * `slotId` — the server-side half of the hard preference block, since a
+     * person can't be in two places during the same slot.
+     */
+    assign(
+        tableId: string,
+        slotId: string,
+        registrant: { type: MeetTheExpertsRegistrantType; id: string },
+        assignedBy: string,
+    ): Promise<void>
+
+    /** No-op if the cell is already empty. */
+    unassign(tableId: string, slotId: string): Promise<void>
+}

--- a/core/website/app/lib/services/meet-the-experts-store.ts
+++ b/core/website/app/lib/services/meet-the-experts-store.ts
@@ -1,0 +1,48 @@
+/**
+ * Meet-the-Experts registration storage. Either a speaker or a sponsor can
+ * register a person for a configured time slot — see `meetTheExperts` on the
+ * conference manifest for the slot list. One row per registrant
+ * (registrantType, registrantId): sessionize_id for a speaker, issue_key for
+ * a sponsor. Speakers additionally answer a preliminary opt-in question
+ * (Yes/No/Maybe/Other) that lives on `SpeakerProfile` — unrelated to this
+ * store, which only holds the actual registration.
+ */
+
+export type MeetTheExpertsRegistrantType = 'speaker' | 'sponsor'
+
+export interface MeetTheExpertsRegistration {
+    registrantType: MeetTheExpertsRegistrantType
+    registrantId: string
+    /** Configured slot ids the registrant wants — may be empty ("none work
+     * for me" is still a deliberate, complete answer). */
+    slots: string[]
+    /** True = use the registrant's default bio text (a speaker's Sessionize
+     * bio, or a sponsor's submitted company blurb); false = bioCustomText. */
+    bioUseDefault: boolean
+    bioCustomText?: string
+    /** Stamped every time the registration is (re)submitted. */
+    respondedAt: number
+    updatedAt: number
+    updatedBy: string
+}
+
+export interface MeetTheExpertsStore {
+    getRegistration(
+        registrantType: MeetTheExpertsRegistrantType,
+        registrantId: string,
+    ): Promise<MeetTheExpertsRegistration | null>
+
+    /** Every registration on file, speaker and sponsor alike — for the admin
+     * scheduling grid, which needs everyone's preferences at once rather
+     * than one lookup per person. */
+    listRegistrations(): Promise<MeetTheExpertsRegistration[]>
+
+    /** Overwrites the selection and re-stamps respondedAt every call — an
+     * empty slot selection is still a deliberate, complete answer. */
+    saveRegistration(
+        registrantType: MeetTheExpertsRegistrantType,
+        registrantId: string,
+        details: { slots: string[]; bioUseDefault: boolean; bioCustomText?: string },
+        updatedBy: string,
+    ): Promise<void>
+}

--- a/core/website/app/lib/services/speakers-store.ts
+++ b/core/website/app/lib/services/speakers-store.ts
@@ -45,6 +45,12 @@ export interface SpeakerSession {
     /** Sessionize's "Owner Confirmed" flag — session-level, set once the
      * session owner confirms their acceptance in Sessionize. */
     isConfirmed: boolean
+    /** False when this session id wasn't in Sessionize's live payload at
+     * all — the fields above are then just a placeholder (raw id as the
+     * title). For a session D1 still has linkage for, that means Sessionize
+     * no longer lists it — most likely declined/withdrawn since the sync
+     * last saw it. */
+    foundInSessionize: boolean
 }
 
 export const QUESTIONS_PREFERENCE_OPTIONS = ['Yes', 'No', 'Yes, moderated', 'Undecided', 'Other'] as const
@@ -76,25 +82,12 @@ export interface SpeakerProfile {
     /** RSVP'd through its own dedicated modal, not the main session-details
      * form — see `saveSpeakerDinnerRsvp`. */
     dietaryRequirements?: string
+    /** Preliminary opt-in — only once this is Yes/Maybe/Other does the
+     * meetTheExperts checklist item appear at all, opening the dedicated
+     * registration modal. The actual registration (slots + bio) lives in
+     * `MeetTheExpertsStore`, not here — see `services.meetTheExperts`. */
     registerMeetTheExperts?: YesNoMaybeOther
     registerMeetTheExpertsOther?: string
-    /** Which configured Meet-the-Experts time-block ids they want to register
-     * for — only meaningful when registerMeetTheExperts is Yes/Maybe/Other.
-     * Saved through its own dedicated modal, see `saveMeetTheExpertsSlots`. */
-    registerMeetTheExpertsSlots: string[]
-    /** Stamped every time the Meet-the-Experts slot selection is submitted
-     * (even with zero slots selected — "none work for me" is still a
-     * completed answer). Same idiom as rsvpSpeakerTrainingRespondedAt. Only
-     * meaningful once registerMeetTheExperts is Yes/Maybe/Other — that's what
-     * makes the checklist item appear at all. */
-    registerMeetTheExpertsRespondedAt?: number
-    /** True = use their Sessionize bio as-is; false = use
-     * meetTheExpertsBioCustomText. Same idiom as introductionUseSessionizeBio
-     * but scoped to Meet the Experts — often not the same text as the
-     * on-stage intro. Saved through the Meet the Experts modal, see
-     * `saveMeetTheExpertsSlots`. */
-    meetTheExpertsBioUseSessionizeBio: boolean
-    meetTheExpertsBioCustomText?: string
     /** RSVP'd through its own dedicated modal, not the main session-details
      * form — see `saveSpeakerDinnerRsvp`. */
     rsvpSpeakersDinner?: YesNoMaybe
@@ -125,8 +118,9 @@ export interface SpeakerProfile {
  * same shape as `SpeakerProfile` minus the fields the store computes itself,
  * dietary requirements (asked as part of the speaker dinner RSVP instead),
  * and the RSVPs, which are saved through their own dedicated actions
- * (`saveSpeakerTrainingRsvp` / `saveSpeakerDinnerRsvp` / `saveMeetTheExpertsSlots`)
- * so that submitting this form can never clobber an RSVP already on file. */
+ * (`saveSpeakerTrainingRsvp` / `saveSpeakerDinnerRsvp` /
+ * `services.meetTheExperts.saveRegistration`) so that submitting this form
+ * can never clobber an RSVP already on file. */
 export type SpeakerProfileInput = Omit<
     SpeakerProfile,
     | 'sessionizeId'
@@ -138,10 +132,6 @@ export type SpeakerProfileInput = Omit<
     | 'rsvpSpeakersDinner'
     | 'rsvpSpeakerTraining'
     | 'rsvpSpeakerTrainingRespondedAt'
-    | 'registerMeetTheExpertsSlots'
-    | 'registerMeetTheExpertsRespondedAt'
-    | 'meetTheExpertsBioUseSessionizeBio'
-    | 'meetTheExpertsBioCustomText'
 >
 
 /** The questions/presentation-format/recording/anything-else fields that
@@ -171,6 +161,15 @@ export interface SpeakerListEntry extends SpeakerRecord {
      * enough for the admin follow-up list to reuse `speakerChecklist`
      * without hydrating full `SessionDetails` rows. */
     sessionDetailsComplete: Record<string, boolean>
+    /** Whether a Meet-the-Experts registration (see `MeetTheExpertsStore`)
+     * is on file for this speaker — same "just enough for `speakerChecklist`"
+     * idiom as `sessionDetailsComplete`. */
+    meetTheExpertsResponded: boolean
+    /** Whether each session has had its backup-speaker acceptance self-
+     * reported by any presenter — session-level, keyed by
+     * sessionizeSessionId, same "just enough for `speakerChecklist`" idiom
+     * as `sessionDetailsComplete`. */
+    sessionBackupAccepted: Record<string, boolean>
 }
 
 /** A speaker + all their co-presenters on shared sessions, for the dashboard. */
@@ -179,6 +178,10 @@ export interface SpeakerWorkspace {
     sessions: Array<{
         session: SpeakerSession
         sessionDetails: SessionDetails | null
+        /** Self-reported "I accept being a backup speaker" for this session
+         * — session-level, shared by every presenter; see
+         * `markBackupAccepted`. Only meaningful for a non-Accepted session. */
+        backupAccepted: boolean
         /** Every speaker on this session, including the logged-in one. */
         presenters: Array<{ speaker: SpeakerRecord; profile: SpeakerProfile | null }>
     }>
@@ -260,17 +263,6 @@ export interface SpeakersStore {
      * on the group's behalf. */
     saveSessionDetails(sessionizeSessionId: string, details: SessionDetailsInput, updatedBy: string): Promise<void>
 
-    /** Meet-the-Experts slot selection + bio, from its own dedicated modal.
-     * Same idiom as saveSpeakerTrainingRsvp for the slots — overwrites the
-     * selection and re-stamps registerMeetTheExpertsRespondedAt every call,
-     * since an empty selection ("none work for me") is still a valid,
-     * deliberate answer. */
-    saveMeetTheExpertsSlots(
-        sessionizeId: string,
-        details: { slots: string[]; bioUseSessionizeBio: boolean; bioCustomText?: string },
-        updatedBy: string,
-    ): Promise<void>
-
     /** Stamps completed_at if not already set. Returns true when this call
      * did the stamping (i.e. the profile just became complete). */
     markProfileCompleted(sessionizeId: string): Promise<boolean>
@@ -307,6 +299,12 @@ export interface SpeakersStore {
      * true only when this call did the stamping, so the caller knows
      * whether to send the notification email. */
     markSessionConfirmed(sessionizeId: string, updatedBy: string): Promise<boolean>
+
+    /** Self-reported "I accept being a backup speaker" from the checklist —
+     * session-level: any presenter on the session may submit it on the
+     * whole session's behalf, same idiom as `saveSessionDetails`. Idempotent
+     * — stamps the acceptance only the first time for a given session. */
+    markBackupAccepted(sessionizeSessionId: string, updatedBy: string): Promise<void>
 
     applySyncPlan(plan: SpeakerSyncPlan): Promise<{
         speakersUpserted: number

--- a/core/website/app/lib/speakers/checklist-items.ts
+++ b/core/website/app/lib/speakers/checklist-items.ts
@@ -34,14 +34,21 @@ export interface OpenModalAction {
  */
 export interface ExternalLinkAction {
     href?: string
-    action?: 'confirm-session' | 'claim-ticket'
+    action?: 'confirm-session' | 'claim-ticket' | 'accept-backup'
     label: string
 }
 
 export type ChecklistItemAction = OpenModalAction | ExternalLinkAction
 
 export interface ChecklistItemDefinition {
-    key: 'confirmSession' | 'sessionDetails' | 'claimTicket' | 'speakerTraining' | 'speakerDinner' | 'meetTheExperts'
+    key:
+        | 'confirmSession'
+        | 'sessionDetails'
+        | 'claimTicket'
+        | 'speakerTraining'
+        | 'speakerDinner'
+        | 'meetTheExperts'
+        | 'acceptBackupSpeaker'
     label: string
     /** Omit for no due date. */
     dueDate?: DateTime
@@ -57,6 +64,14 @@ export const SPEAKER_CHECKLIST_ITEMS: ChecklistItemDefinition[] = [
             { href: 'https://sessionize.com/app/speaker', label: 'Open Sessionize ↗' },
             { action: 'confirm-session', label: "I've already confirmed it" },
         ],
+    },
+    {
+        // Only shown instead of confirmSession, for a speaker with no
+        // Accepted session — see `isBackupSpeaker` in checklist.ts.
+        key: 'acceptBackupSpeaker',
+        label: 'Accept being a backup speaker',
+        dueDate: DateTime.fromISO('2026-08-21T17:00:00', { zone: 'Australia/Perth' }),
+        actions: [{ action: 'accept-backup', label: 'I accept being a backup speaker' }],
     },
     {
         key: 'sessionDetails',

--- a/core/website/app/lib/speakers/checklist.test.ts
+++ b/core/website/app/lib/speakers/checklist.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest'
 import type { SpeakerProfile } from '../services/speakers-store'
 import {
     dueDateRemainingLabel,
+    isBackupAccepted,
+    isBackupSpeaker,
     isMeetTheExpertsApplicable,
     isMeetTheExpertsRegistrationComplete,
     isSessionConfirmed,
@@ -24,14 +26,12 @@ function profile(overrides: Partial<SpeakerProfile> = {}): SpeakerProfile {
         sessionizeId: 'spk-1',
         introductionUseSessionizeBio: true,
         rsvpSpeakerTraining: [],
-        registerMeetTheExpertsSlots: [],
-        meetTheExpertsBioUseSessionizeBio: true,
         ...overrides,
     }
 }
 
 function session(overrides: Partial<SpeakerSessionChecklistInput> = {}): SpeakerSessionChecklistInput {
-    return { status: 'Accepted', isConfirmed: false, sessionDetailsComplete: true, ...overrides }
+    return { status: 'Accepted', isConfirmed: false, sessionDetailsComplete: true, backupAccepted: false, ...overrides }
 }
 
 describe('isSessionDetailsComplete', () => {
@@ -67,14 +67,9 @@ describe('isMeetTheExpertsApplicable', () => {
 })
 
 describe('isMeetTheExpertsRegistrationComplete', () => {
-    it('is done once the slot-selection modal has been submitted at all, even with zero slots selected', () => {
-        expect(isMeetTheExpertsRegistrationComplete(profile({ registerMeetTheExperts: 'Yes' }))).toBe(false)
-        expect(
-            isMeetTheExpertsRegistrationComplete(
-                profile({ registerMeetTheExperts: 'Yes', registerMeetTheExpertsRespondedAt: 1700000000 }),
-            ),
-        ).toBe(true)
-        expect(isMeetTheExpertsRegistrationComplete(null)).toBe(false)
+    it('is done once the registration has been submitted at all, even with zero slots selected', () => {
+        expect(isMeetTheExpertsRegistrationComplete(undefined)).toBe(false)
+        expect(isMeetTheExpertsRegistrationComplete(1700000000)).toBe(true)
     })
 })
 
@@ -128,25 +123,97 @@ describe('isSessionConfirmed', () => {
     })
 })
 
+describe('isBackupSpeaker', () => {
+    it('is false with no sessions at all', () => {
+        expect(isBackupSpeaker([])).toBe(false)
+    })
+
+    it('is true when every session is non-Accepted', () => {
+        expect(isBackupSpeaker([session({ status: 'Waitlisted' })])).toBe(true)
+    })
+
+    it('is false once at least one session is Accepted', () => {
+        expect(isBackupSpeaker([session({ status: 'Accepted' })])).toBe(false)
+        expect(isBackupSpeaker([session({ status: 'Accepted' }), session({ status: 'Waitlisted' })])).toBe(false)
+    })
+})
+
+describe('isBackupAccepted', () => {
+    it('is not done with no backup sessions at all', () => {
+        expect(isBackupAccepted([])).toBe(false)
+        expect(isBackupAccepted([session({ status: 'Accepted' })])).toBe(false)
+    })
+
+    it('is done once every non-Accepted session has been accepted', () => {
+        expect(isBackupAccepted([session({ status: 'Waitlisted', backupAccepted: false })])).toBe(false)
+        expect(isBackupAccepted([session({ status: 'Waitlisted', backupAccepted: true })])).toBe(true)
+        expect(
+            isBackupAccepted([
+                session({ status: 'Waitlisted', backupAccepted: true }),
+                session({ status: 'Waitlisted', backupAccepted: false }),
+            ]),
+        ).toBe(false)
+    })
+
+    it('counts a co-presenter accepting on a shared session — session-level, not speaker-level', () => {
+        // backupAccepted is set on the session itself regardless of which
+        // presenter submitted it, so this speaker's own view of a session a
+        // co-presenter already accepted just reads true.
+        expect(isBackupAccepted([session({ status: 'Waitlisted', backupAccepted: true })])).toBe(true)
+    })
+})
+
 describe('speakerChecklist', () => {
     it('handles a missing profile — everything outstanding', () => {
-        expect(speakerChecklist(null, [], NOW).every((i) => !i.done)).toBe(true)
+        expect(speakerChecklist(null, [], false, NOW).every((i) => !i.done)).toBe(true)
     })
 
     it('omits meetTheExperts until the speaker opts in', () => {
-        expect(speakerChecklist(null, [], NOW).some((i) => i.key === 'meetTheExperts')).toBe(false)
-        expect(speakerChecklist(profile({ registerMeetTheExperts: 'No' }), [], NOW).some((i) => i.key === 'meetTheExperts')).toBe(
-            false,
-        )
+        expect(speakerChecklist(null, [], false, NOW).some((i) => i.key === 'meetTheExperts')).toBe(false)
         expect(
-            speakerChecklist(profile({ registerMeetTheExperts: 'Yes' }), [], NOW).some((i) => i.key === 'meetTheExperts'),
+            speakerChecklist(profile({ registerMeetTheExperts: 'No' }), [], false, NOW).some((i) => i.key === 'meetTheExperts'),
+        ).toBe(false)
+        expect(
+            speakerChecklist(profile({ registerMeetTheExperts: 'Yes' }), [], false, NOW).some((i) => i.key === 'meetTheExperts'),
         ).toBe(true)
     })
 
+    it('reflects the passed-in meetTheExpertsResponded flag, not profile data', () => {
+        const withProfile = profile({ registerMeetTheExperts: 'Yes' })
+        expect(
+            speakerChecklist(withProfile, [], false, NOW).find((i) => i.key === 'meetTheExperts')?.done,
+        ).toBe(false)
+        expect(
+            speakerChecklist(withProfile, [], true, NOW).find((i) => i.key === 'meetTheExperts')?.done,
+        ).toBe(true)
+    })
+
+    it('swaps confirmSession for acceptBackupSpeaker when the speaker has no Accepted session', () => {
+        const notBackup = speakerChecklist(profile(), [session({ status: 'Accepted' })], false, NOW)
+        expect(notBackup.some((i) => i.key === 'confirmSession')).toBe(true)
+        expect(notBackup.some((i) => i.key === 'acceptBackupSpeaker')).toBe(false)
+
+        const backup = speakerChecklist(profile(), [session({ status: 'Waitlisted' })], false, NOW)
+        expect(backup.some((i) => i.key === 'confirmSession')).toBe(false)
+        expect(backup.some((i) => i.key === 'acceptBackupSpeaker')).toBe(true)
+
+        const acceptedItem = backup.find((i) => i.key === 'acceptBackupSpeaker')
+        expect(acceptedItem?.done).toBe(false)
+        const done = speakerChecklist(
+            profile(),
+            [session({ status: 'Waitlisted', backupAccepted: true })],
+            false,
+            NOW,
+        )
+        expect(done.find((i) => i.key === 'acceptBackupSpeaker')?.done).toBe(true)
+    })
+
     it("carries each item's configured due date through as an ISO string", () => {
-        const items = speakerChecklist(profile({ registerMeetTheExperts: 'Yes' }), [], NOW)
+        const items = speakerChecklist(profile({ registerMeetTheExperts: 'Yes' }), [], false, NOW)
         for (const definition of SPEAKER_CHECKLIST_ITEMS) {
-            expect(items.find((i) => i.key === definition.key)?.dueDateIso).toBe(definition.dueDate?.toISO())
+            const item = items.find((i) => i.key === definition.key)
+            if (!item) continue // filtered out in this scenario, e.g. acceptBackupSpeaker (not a backup speaker)
+            expect(item.dueDateIso).toBe(definition.dueDate?.toISO())
         }
     })
 
@@ -156,18 +223,17 @@ describe('speakerChecklist', () => {
             rsvpSpeakersDinner: 'Yes',
             ticketClaimedAt: 1700000000,
             registerMeetTheExperts: 'Yes',
-            registerMeetTheExpertsRespondedAt: 1700000000,
         })
         const sessions: SpeakerSessionChecklistInput[] = [session({ status: 'Accepted', isConfirmed: true })]
-        expect(speakerChecklist(complete, sessions, NOW).every((i) => i.done)).toBe(true)
+        expect(speakerChecklist(complete, sessions, true, NOW).every((i) => i.done)).toBe(true)
     })
 
     it('flags isPastDue only once an item\'s own due date has actually passed', () => {
-        expect(speakerChecklist(null, [], NOW).every((i) => !i.isPastDue)).toBe(true)
+        expect(speakerChecklist(null, [], false, NOW).every((i) => !i.isPastDue)).toBe(true)
 
         const confirmSessionDueDate = SPEAKER_CHECKLIST_ITEMS.find((d) => d.key === 'confirmSession')?.dueDate
         if (!confirmSessionDueDate) throw new Error('confirmSession is expected to have a due date')
-        const items = speakerChecklist(null, [], confirmSessionDueDate.plus({ minutes: 1 }))
+        const items = speakerChecklist(null, [], false, confirmSessionDueDate.plus({ minutes: 1 }))
         expect(items.find((i) => i.key === 'confirmSession')?.isPastDue).toBe(true)
         // sessionDetails is due later than confirmSession, so it isn't past due yet.
         expect(items.find((i) => i.key === 'sessionDetails')?.isPastDue).toBe(false)

--- a/core/website/app/lib/speakers/checklist.ts
+++ b/core/website/app/lib/speakers/checklist.ts
@@ -31,11 +31,14 @@ export function isMeetTheExpertsApplicable(profile: SpeakerProfile | null): bool
     return profile?.registerMeetTheExperts === 'Yes' || profile?.registerMeetTheExperts === 'Maybe' || profile?.registerMeetTheExperts === 'Other'
 }
 
-/** Done once the Meet-the-Experts slot-selection modal has been submitted at
- * all — same idiom as `isSpeakerTrainingRsvpComplete`: an empty slot
- * selection ("none work for me") is still a deliberate, complete answer. */
-export function isMeetTheExpertsRegistrationComplete(profile: SpeakerProfile | null): boolean {
-    return Boolean(profile?.registerMeetTheExpertsRespondedAt)
+/** Done once the Meet-the-Experts registration (see `MeetTheExpertsStore`)
+ * has been submitted at all — same idiom as `isSpeakerTrainingRsvpComplete`:
+ * an empty slot selection ("none work for me") is still a deliberate,
+ * complete answer. Takes the registration's `respondedAt` directly rather
+ * than a `SpeakerProfile`, since the registration now lives in its own
+ * table. */
+export function isMeetTheExpertsRegistrationComplete(respondedAt: number | undefined): boolean {
+    return Boolean(respondedAt)
 }
 
 /** Done once the training RSVP modal has been submitted at all — an empty
@@ -51,6 +54,23 @@ export function isSpeakerDinnerRsvpComplete(profile: SpeakerProfile | null): boo
 
 export function isTicketClaimed(profile: SpeakerProfile | null): boolean {
     return Boolean(profile?.ticketClaimedAt)
+}
+
+/** A backup speaker has sessions, but none of them Accepted (e.g. all
+ * Waitlisted) — nothing to confirm in Sessionize, so `confirmSession` is
+ * filtered out in favour of `acceptBackupSpeaker`; see `speakerChecklist`.
+ * A speaker with no sessions at all isn't "backup", just not yet synced. */
+export function isBackupSpeaker(sessions: SpeakerSessionChecklistInput[]): boolean {
+    return sessions.length > 0 && sessions.every((s) => s.status !== 'Accepted')
+}
+
+/** Done once every non-Accepted (backup) session has had its acceptance
+ * self-reported — session-level and shared by every presenter (see
+ * `backupAccepted` on `SpeakerSessionChecklistInput`), so a co-presenter
+ * accepting on a dual-speaker session counts too. */
+export function isBackupAccepted(sessions: SpeakerSessionChecklistInput[]): boolean {
+    const backupSessions = sessions.filter((s) => s.status !== 'Accepted')
+    return backupSessions.length > 0 && backupSessions.every((s) => s.backupAccepted)
 }
 
 export type ChecklistUrgency = 'normal' | 'upcoming' | 'overdue'
@@ -89,6 +109,10 @@ export interface SpeakerSessionChecklistInput {
     status: string
     isConfirmed: boolean
     sessionDetailsComplete: boolean
+    /** Self-reported "I accept being a backup speaker" for this session —
+     * session-level, set by any presenter on it. Only meaningful for a
+     * non-Accepted session; see `isBackupAccepted`. */
+    backupAccepted: boolean
 }
 
 /** Done once every Accepted session is confirmed in Sessionize (synced), or
@@ -116,9 +140,11 @@ export interface SpeakerChecklistItem {
 
 /** One "is it done" predicate per item key — kept in code (rather than
  * checklist-items.ts) since it depends on real profile/session data. Every
- * key in `SPEAKER_CHECKLIST_ITEMS` must have an entry here. */
+ * key except `meetTheExperts` (special-cased in `speakerChecklist`, since its
+ * completion comes from a `MeetTheExpertsRegistration`, not `profile`/
+ * `sessions`) must have an entry here. */
 const CHECKLIST_DONE_PREDICATES: Record<
-    ChecklistItemDefinition['key'],
+    Exclude<ChecklistItemDefinition['key'], 'meetTheExperts'>,
     (profile: SpeakerProfile | null, sessions: SpeakerSessionChecklistInput[]) => boolean
 > = {
     confirmSession: (profile, sessions) => isSessionConfirmed(profile, sessions),
@@ -126,18 +152,28 @@ const CHECKLIST_DONE_PREDICATES: Record<
     claimTicket: (profile) => isTicketClaimed(profile),
     speakerTraining: (profile) => isSpeakerTrainingRsvpComplete(profile),
     speakerDinner: (profile) => isSpeakerDinnerRsvpComplete(profile),
-    meetTheExperts: (profile) => isMeetTheExpertsRegistrationComplete(profile),
+    acceptBackupSpeaker: (_profile, sessions) => isBackupAccepted(sessions),
 }
 
 export function speakerChecklist(
     profile: SpeakerProfile | null,
     sessions: SpeakerSessionChecklistInput[],
+    meetTheExpertsResponded: boolean,
     now: DateTime = DateTime.now(),
 ): SpeakerChecklistItem[] {
-    return SPEAKER_CHECKLIST_ITEMS.filter(
-        (definition) => definition.key !== 'meetTheExperts' || isMeetTheExpertsApplicable(profile),
-    ).map((definition) => {
-        const done = CHECKLIST_DONE_PREDICATES[definition.key](profile, sessions)
+    const backup = isBackupSpeaker(sessions)
+    return SPEAKER_CHECKLIST_ITEMS.filter((definition) => {
+        if (definition.key === 'meetTheExperts') return isMeetTheExpertsApplicable(profile)
+        // A backup speaker has no Accepted session to confirm — they get
+        // acceptBackupSpeaker instead of confirmSession.
+        if (definition.key === 'confirmSession') return !backup
+        if (definition.key === 'acceptBackupSpeaker') return backup
+        return true
+    }).map((definition) => {
+        const done =
+            definition.key === 'meetTheExperts'
+                ? isMeetTheExpertsRegistrationComplete(meetTheExpertsResponded ? 1 : undefined)
+                : CHECKLIST_DONE_PREDICATES[definition.key](profile, sessions)
         const dueDateIso = definition.dueDate?.toISO() ?? undefined
         const isPastDue = Boolean(dueDateIso && DateTime.fromISO(dueDateIso) < now)
         return {

--- a/core/website/app/lib/speakers/contact-import.test.ts
+++ b/core/website/app/lib/speakers/contact-import.test.ts
@@ -1,5 +1,12 @@
+import { utils as sheetUtils, write as writeWorkbook } from 'xlsx'
 import { describe, expect, it } from 'vitest'
-import { computeContactImportPlan, parseCsv, parseSpeakerContactsCsv, type CsvSpeakerRow } from './contact-import'
+import {
+    computeContactImportPlan,
+    parseCsv,
+    parseSpeakerContactsCsv,
+    parseSpeakerContactsExcel,
+    type CsvSpeakerRow,
+} from './contact-import'
 
 describe('parseCsv', () => {
     it('splits simple rows', () => {
@@ -125,6 +132,62 @@ describe('parseSpeakerContactsCsv', () => {
 
     it('returns an empty array for an empty file', () => {
         expect(parseSpeakerContactsCsv('')).toEqual([])
+    })
+})
+
+function xlsxBuffer(rows: unknown[][]): ArrayBuffer {
+    const workbook = sheetUtils.book_new()
+    const sheet = sheetUtils.aoa_to_sheet(rows)
+    sheetUtils.book_append_sheet(workbook, sheet, 'Sheet1')
+    return writeWorkbook(workbook, { type: 'array', bookType: 'xlsx' }) as ArrayBuffer
+}
+
+describe('parseSpeakerContactsExcel', () => {
+    it('extracts the same fields as the CSV import, including a numeric-typed Session Id', () => {
+        const buffer = xlsxBuffer([
+            ['Session Id', 'Title', 'Speaker Id', 'FirstName', 'LastName', 'Email'],
+            [1231798, 'A great talk', 'spk-1', 'Ada', 'Lovelace', 'ada@example.com'],
+        ])
+
+        expect(parseSpeakerContactsExcel(buffer)).toEqual([
+            {
+                sessionizeId: 'spk-1',
+                sessionId: '1231798',
+                email: 'ada@example.com',
+                sessionTitle: 'A great talk',
+                fullName: 'Ada Lovelace',
+            },
+        ])
+    })
+
+    it('only reads the first sheet', () => {
+        const workbook = sheetUtils.book_new()
+        sheetUtils.book_append_sheet(
+            workbook,
+            sheetUtils.aoa_to_sheet([
+                ['Speaker Id', 'Email'],
+                ['spk-1', 'ada@example.com'],
+            ]),
+            'First',
+        )
+        sheetUtils.book_append_sheet(
+            workbook,
+            sheetUtils.aoa_to_sheet([
+                ['Speaker Id', 'Email'],
+                ['spk-2', 'other@example.com'],
+            ]),
+            'Second',
+        )
+        const buffer = writeWorkbook(workbook, { type: 'array', bookType: 'xlsx' }) as ArrayBuffer
+
+        expect(parseSpeakerContactsExcel(buffer)).toEqual([
+            { sessionizeId: 'spk-1', sessionId: '', email: 'ada@example.com', sessionTitle: '', fullName: '' },
+        ])
+    })
+
+    it('throws when the required columns are missing', () => {
+        const buffer = xlsxBuffer([['Title', 'Description'], ['A', 'B']])
+        expect(() => parseSpeakerContactsExcel(buffer)).toThrow(/Speaker Id/)
     })
 })
 

--- a/core/website/app/lib/speakers/contact-import.ts
+++ b/core/website/app/lib/speakers/contact-import.ts
@@ -1,12 +1,14 @@
 /**
- * CSV import for speaker portal access. Sessionize's "flattened accepted
- * sessions" export has one row per (session, speaker) pair — Session Id +
- * Speaker Id + Email is everything needed to grant portal access; speaker
- * bio/sessions/links etc. are already sourced from the Sessionize API sync
- * (see sync-plan.ts) so this only ever reads the three columns above (plus
- * name, for display). No I/O — parsing and planning are pure so both can be
- * unit tested; the D1 write lives in the route action.
+ * CSV/Excel import for speaker portal access. Sessionize's "flattened
+ * accepted sessions" export has one row per (session, speaker) pair —
+ * Session Id + Speaker Id + Email is everything needed to grant portal
+ * access; speaker bio/sessions/links etc. are already sourced from the
+ * Sessionize API sync (see sync-plan.ts) so this only ever reads the three
+ * columns above (plus name, for display). No I/O — parsing and planning are
+ * pure so both can be unit tested; the D1 write lives in the route action.
  */
+
+import { read as readWorkbook, utils as sheetUtils } from 'xlsx'
 
 export interface CsvSpeakerRow {
     sessionizeId: string
@@ -87,7 +89,24 @@ export function parseCsv(text: string): string[][] {
  * export is sourced from the API instead. Throws if the required columns
  * aren't present (wrong export, or a hand-edited file missing a header). */
 export function parseSpeakerContactsCsv(csvText: string): CsvSpeakerRow[] {
-    const rows = parseCsv(csvText)
+    return speakerContactsFromTable(parseCsv(csvText))
+}
+
+/** Same export, saved as Excel instead of CSV — reads the first sheet only.
+ * Numbers/dates are read as their displayed text (not raw serial values) so
+ * a Speaker Id or Session Id typed as a number still comes through as the
+ * same string a CSV export would have produced. */
+export function parseSpeakerContactsExcel(fileBuffer: ArrayBuffer): CsvSpeakerRow[] {
+    const workbook = readWorkbook(fileBuffer, { type: 'array' })
+    const firstSheetName = workbook.SheetNames[0]
+    if (!firstSheetName) return []
+
+    const sheet = workbook.Sheets[firstSheetName]
+    const rows = sheetUtils.sheet_to_json<string[]>(sheet, { header: 1, raw: false, defval: '' })
+    return speakerContactsFromTable(rows)
+}
+
+function speakerContactsFromTable(rows: string[][]): CsvSpeakerRow[] {
     if (rows.length === 0) return []
 
     const header = rows[0].map((h) => h.trim())
@@ -101,7 +120,7 @@ export function parseSpeakerContactsCsv(csvText: string): CsvSpeakerRow[] {
     const idxLastName = indexOf('LastName')
 
     if (idxSessionizeId === -1 || idxEmail === -1) {
-        throw new Error('CSV is missing the required "Speaker Id" and/or "Email" columns')
+        throw new Error('File is missing the required "Speaker Id" and/or "Email" columns')
     }
 
     const dataRows = rows.slice(1)

--- a/core/website/app/lib/speakers/dashboard-view.server.ts
+++ b/core/website/app/lib/speakers/dashboard-view.server.ts
@@ -12,6 +12,7 @@ import {
     type SpeakerSessionDetailsSection,
     type SpeakerWorkspaceSessionView,
 } from './workspace-view.server'
+import type { MeetTheExpertsRegistration } from '../services/meet-the-experts-store'
 import type { SpeakerWorkspace, YesNoMaybe } from '../services/speakers-store'
 
 /**
@@ -29,6 +30,11 @@ export interface SpeakerDashboardView {
 
     checklist: SpeakerChecklistItem[]
     ticketClaimUrl?: string
+    /** The viewer's own sessions still needing backup-speaker acceptance —
+     * feeds the checklist's "I accept being a backup speaker" button, which
+     * submits acceptance for all of them at once (session-level, shared by
+     * co-presenters — see `markBackupAccepted`). */
+    backupSessionIds: string[]
 
     conferenceName: string
     conferenceDateLabel: string | null
@@ -61,6 +67,7 @@ export function buildSpeakerDashboardView(
     context: { get<T>(context: RouterContext<T>): T },
     workspace: SpeakerWorkspace,
     targetSessionizeId: string,
+    meetTheExpertsRegistration: MeetTheExpertsRegistration | null,
 ): SpeakerDashboardView {
     const now = getDateTimeProvider(context).nowDate()
     const conferenceDateIso = getConferenceState(context).conference.date
@@ -74,12 +81,16 @@ export function buildSpeakerDashboardView(
             .flatMap(({ presenters }) => presenters)
             .find((p) => p.speaker.sessionizeId === targetSessionizeId)?.profile ?? null
 
-    const checklistSessions: SpeakerSessionChecklistInput[] = workspace.sessions.map(({ session, sessionDetails }) => ({
+    const checklistSessions: SpeakerSessionChecklistInput[] = workspace.sessions.map(({ session, sessionDetails, backupAccepted }) => ({
         status: session.status,
         isConfirmed: session.isConfirmed,
         sessionDetailsComplete: Boolean(sessionDetails?.questionsPreference),
+        backupAccepted,
     }))
-    const checklist = speakerChecklist(ownProfile, checklistSessions, now)
+    const checklist = speakerChecklist(ownProfile, checklistSessions, Boolean(meetTheExpertsRegistration), now)
+    const backupSessionIds = workspace.sessions
+        .filter(({ session, backupAccepted }) => session.status !== 'Accepted' && !backupAccepted)
+        .map(({ session }) => session.sessionizeSessionId)
 
     const reminders = upcomingRsvpedEvents(
         ownProfile,
@@ -114,6 +125,7 @@ export function buildSpeakerDashboardView(
 
         checklist,
         ticketClaimUrl: checklistConfig?.ticketClaimUrl,
+        backupSessionIds,
 
         conferenceName: conferenceManifest.public.name,
         conferenceDateLabel: conferenceDate?.toLocaleString(DateTime.DATE_HUGE, { locale: 'en-AU' }) ?? null,
@@ -137,12 +149,12 @@ export function buildSpeakerDashboardView(
         dinnerResponse: ownProfile?.rsvpSpeakersDinner,
         dinnerDietaryRequirements: ownProfile?.dietaryRequirements,
 
-        meetTheExpertsSlots: checklistConfig?.meetTheExpertsSlots ?? [],
-        meetTheExpertsResponded: Boolean(ownProfile?.registerMeetTheExpertsRespondedAt),
-        meetTheExpertsSelectedSlotIds: ownProfile?.registerMeetTheExpertsSlots ?? [],
+        meetTheExpertsSlots: conferenceManifest.meetTheExperts?.slots ?? [],
+        meetTheExpertsResponded: Boolean(meetTheExpertsRegistration),
+        meetTheExpertsSelectedSlotIds: meetTheExpertsRegistration?.slots ?? [],
         meetTheExpertsBio: workspace.speaker.bio,
-        meetTheExpertsBioUseSessionizeBio: ownProfile?.meetTheExpertsBioUseSessionizeBio ?? true,
-        meetTheExpertsBioCustomText: ownProfile?.meetTheExpertsBioCustomText,
+        meetTheExpertsBioUseSessionizeBio: meetTheExpertsRegistration?.bioUseDefault ?? true,
+        meetTheExpertsBioCustomText: meetTheExpertsRegistration?.bioCustomText,
         sessionDetailsIntroText: ownProfile?.introductionCustomText,
     }
 }

--- a/core/website/app/lib/speakers/follow-up-emails.ts
+++ b/core/website/app/lib/speakers/follow-up-emails.ts
@@ -118,4 +118,20 @@ ${conferenceName} team`,
 <p>Please <a href="${portalUrl}">log in to the speaker portal</a> to choose your times.</p>
 <p>Thanks,<br/>${conferenceName} team</p>`,
     },
+
+    acceptBackupSpeaker: {
+        subject: 'Please confirm you accept being a backup speaker',
+        text: ({ firstName, portalUrl, conferenceName }) => `Hi ${firstName},
+
+Just a friendly reminder that we still need you to confirm you accept being a backup speaker for ${conferenceName}.
+
+Log in to the speaker portal to sort it out: ${portalUrl}
+
+Thanks,
+${conferenceName} team`,
+        html: ({ firstName, portalUrl, conferenceName }) => `<p>Hi ${firstName},</p>
+<p>Just a friendly reminder that we still need you to confirm you accept being a backup speaker for ${conferenceName}.</p>
+<p>Please <a href="${portalUrl}">log in to the speaker portal</a> to sort it out.</p>
+<p>Thanks,<br/>${conferenceName} team</p>`,
+    },
 }

--- a/core/website/app/lib/speakers/follow-up.test.ts
+++ b/core/website/app/lib/speakers/follow-up.test.ts
@@ -16,6 +16,8 @@ function speaker(overrides: Partial<SpeakerListEntry> = {}): SpeakerListEntry {
         sessions: [],
         profile: null,
         sessionDetailsComplete: {},
+        meetTheExpertsResponded: false,
+        sessionBackupAccepted: {},
         ...overrides,
     }
 }
@@ -31,8 +33,6 @@ describe('speakersMissingChecklistItem', () => {
             profile: {
                 sessionizeId: 'spk-1',
                 introductionUseSessionizeBio: true,
-                registerMeetTheExpertsSlots: [],
-                meetTheExpertsBioUseSessionizeBio: true,
                 rsvpSpeakerTraining: [],
                 rsvpSpeakerTrainingRespondedAt: 1700000000,
             },
@@ -54,6 +54,7 @@ describe('speakersMissingChecklistItem', () => {
                     talkTopics: [],
                     status: 'Accepted',
                     isConfirmed: true,
+                    foundInSessionize: true,
                 },
             ],
         })
@@ -67,6 +68,7 @@ describe('speakersMissingChecklistItem', () => {
                     talkTopics: [],
                     status: 'Accepted',
                     isConfirmed: false,
+                    foundInSessionize: true,
                 },
             ],
         })

--- a/core/website/app/lib/speakers/follow-up.ts
+++ b/core/website/app/lib/speakers/follow-up.ts
@@ -27,8 +27,11 @@ export function speakersMissingChecklistItem(
                 status: session.status,
                 isConfirmed: session.isConfirmed,
                 sessionDetailsComplete: speaker.sessionDetailsComplete[session.sessionizeSessionId] ?? false,
+                backupAccepted: speaker.sessionBackupAccepted[session.sessionizeSessionId] ?? false,
             }))
-            const item = speakerChecklist(speaker.profile, sessions, now).find((i) => i.key === itemKey)
+            const item = speakerChecklist(speaker.profile, sessions, speaker.meetTheExpertsResponded, now).find(
+                (i) => i.key === itemKey,
+            )
             return item ? !item.done : false
         })
         .map((speaker) => ({ sessionizeId: speaker.sessionizeId, fullName: speaker.fullName, contacts: speaker.contacts }))

--- a/core/website/app/lib/speakers/map-sessionize.ts
+++ b/core/website/app/lib/speakers/map-sessionize.ts
@@ -87,12 +87,18 @@ export function toPortalSession(session: Session, categoryNames: PortalCategoryN
 }
 
 /** The Sessionize endpoint configured for the speaker portal's year, if any
- * — same resolution the sync service uses. */
+ * — same resolution the sync service uses. Prefers `allSessionsEndpoint`
+ * over the plain `sessionizeEndpoint`: the portal grants access on
+ * Accepted *and* Waitlisted sessions (see `portalAccessStatuses`), but
+ * Sessionize's plain "Sessions" view stops listing non-Accepted sessions
+ * once the event's agenda is published — same reason admin/voting pages
+ * use `allSessionsEndpoint` instead. Falls back to `sessionizeEndpoint` for
+ * years/forks that haven't configured the all-statuses endpoint. */
 export function resolveSpeakerPortalSessionizeEndpoint(config: AppConfig): string | undefined {
     const portalConfig = conferenceManifest.speakerPortal
     if (!portalConfig) return undefined
 
     const yearConfig = getYearConfig(portalConfig.year, config)
     if (yearConfig.kind !== 'conference' || yearConfig.sessions?.kind !== 'sessionize') return undefined
-    return yearConfig.sessions.sessionizeEndpoint
+    return yearConfig.sessions.allSessionsEndpoint ?? yearConfig.sessions.sessionizeEndpoint
 }

--- a/core/website/app/lib/speakers/profile-form.server.ts
+++ b/core/website/app/lib/speakers/profile-form.server.ts
@@ -38,8 +38,10 @@ export interface MeetTheExpertsFormInput {
 /**
  * Parses the "Meet the Experts" modal's combined form (slot checkboxes +
  * the "use Sessionize bio or write a custom one" bio field, same idiom as
- * the session-details introduction) into what `saveMeetTheExpertsSlots`
- * accepts. Shared by the speaker's own action and the admin preview's.
+ * the session-details introduction) into what
+ * `services.meetTheExperts.saveRegistration` accepts (`bioUseSessionizeBio`
+ * maps onto its generic `bioUseDefault`). Shared by the speaker's own action
+ * and the admin preview's.
  */
 export function parseMeetTheExpertsForm(formData: FormData): MeetTheExpertsFormInput {
     return {

--- a/core/website/app/lib/speakers/rsvp-summary.test.ts
+++ b/core/website/app/lib/speakers/rsvp-summary.test.ts
@@ -6,9 +6,7 @@ function profile(overrides: Partial<SpeakerProfile> = {}): SpeakerProfile {
     return {
         sessionizeId: 'sp-1',
         introductionUseSessionizeBio: true,
-        registerMeetTheExpertsSlots: [],
         rsvpSpeakerTraining: [],
-        meetTheExpertsBioUseSessionizeBio: true,
         ...overrides,
     }
 }

--- a/core/website/app/lib/speakers/session-export.test.ts
+++ b/core/website/app/lib/speakers/session-export.test.ts
@@ -16,6 +16,8 @@ function speaker(overrides: Partial<SpeakerListEntry> = {}): SpeakerListEntry {
         sessions: [],
         profile: null,
         sessionDetailsComplete: {},
+        meetTheExpertsResponded: false,
+        sessionBackupAccepted: {},
         ...overrides,
     }
 }
@@ -34,6 +36,7 @@ describe('buildSessionExport', () => {
                         talkTopics: [],
                         status: 'Accepted',
                         isConfirmed: false,
+                        foundInSessionize: true,
                     },
                 ],
             }),
@@ -50,6 +53,7 @@ describe('buildSessionExport', () => {
                         talkTopics: [],
                         status: 'Accepted',
                         isConfirmed: false,
+                        foundInSessionize: true,
                     },
                 ],
             }),
@@ -80,6 +84,7 @@ describe('buildSessionExport', () => {
                         talkTopics: [],
                         status: 'Waitlisted',
                         isConfirmed: false,
+                        foundInSessionize: true,
                     },
                 ],
             }),
@@ -92,7 +97,7 @@ describe('buildSessionExport', () => {
         const speakers: SpeakerListEntry[] = [
             speaker({
                 active: false,
-                sessions: [{ sessionizeSessionId: 'sess-1', sessionTitle: 'Gone', talkTopics: [], status: 'Accepted', isConfirmed: false }],
+                sessions: [{ sessionizeSessionId: 'sess-1', sessionTitle: 'Gone', talkTopics: [], status: 'Accepted', isConfirmed: false, foundInSessionize: true }],
             }),
         ]
 
@@ -103,11 +108,11 @@ describe('buildSessionExport', () => {
         const speakers: SpeakerListEntry[] = [
             speaker({
                 sessionizeId: 'spk-1',
-                sessions: [{ sessionizeSessionId: 'sess-b', sessionTitle: 'Zebra talk', talkTopics: [], status: 'Accepted', isConfirmed: false }],
+                sessions: [{ sessionizeSessionId: 'sess-b', sessionTitle: 'Zebra talk', talkTopics: [], status: 'Accepted', isConfirmed: false, foundInSessionize: true }],
             }),
             speaker({
                 sessionizeId: 'spk-2',
-                sessions: [{ sessionizeSessionId: 'sess-a', sessionTitle: 'Aardvark talk', talkTopics: [], status: 'Accepted', isConfirmed: false }],
+                sessions: [{ sessionizeSessionId: 'sess-a', sessionTitle: 'Aardvark talk', talkTopics: [], status: 'Accepted', isConfirmed: false, foundInSessionize: true }],
             }),
         ]
 
@@ -123,6 +128,7 @@ describe('collectPhotoSpeakers', () => {
             talkTopics: [],
             status: 'Accepted',
             isConfirmed: false,
+                        foundInSessionize: true,
         }
         const speakers: SpeakerListEntry[] = [
             speaker({ sessionizeId: 'spk-1', fullName: 'Ada Lovelace', sessions: [inSession] }),
@@ -139,8 +145,8 @@ describe('collectPhotoSpeakers', () => {
         const shared = speaker({
             sessionizeId: 'spk-1',
             sessions: [
-                { sessionizeSessionId: 'sess-1', sessionTitle: 'Talk One', talkTopics: [], status: 'Accepted', isConfirmed: false },
-                { sessionizeSessionId: 'sess-2', sessionTitle: 'Talk Two', talkTopics: [], status: 'Accepted', isConfirmed: false },
+                { sessionizeSessionId: 'sess-1', sessionTitle: 'Talk One', talkTopics: [], status: 'Accepted', isConfirmed: false, foundInSessionize: true },
+                { sessionizeSessionId: 'sess-2', sessionTitle: 'Talk Two', talkTopics: [], status: 'Accepted', isConfirmed: false, foundInSessionize: true },
             ],
         })
         const sessions = buildSessionExport([shared])

--- a/core/website/app/routes/admin.speakers.$sessionizeId.tsx
+++ b/core/website/app/routes/admin.speakers.$sessionizeId.tsx
@@ -32,14 +32,17 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
     await requireAdmin(request, context)
     const services = getServices(context)
 
-    const workspace = await services.speakers.getWorkspace(params.sessionizeId)
+    const [workspace, meetTheExpertsRegistration] = await Promise.all([
+        services.speakers.getWorkspace(params.sessionizeId),
+        services.meetTheExperts.getRegistration('speaker', params.sessionizeId),
+    ])
     if (!workspace) {
         throw new Response('Not Found', { status: 404 })
     }
 
     return {
         fullName: workspace.speaker.fullName,
-        ...buildSpeakerDashboardView(context, workspace, params.sessionizeId),
+        ...buildSpeakerDashboardView(context, workspace, params.sessionizeId, meetTheExpertsRegistration),
     }
 }
 
@@ -78,6 +81,18 @@ export async function action({ request, context }: Route.ActionArgs) {
         }
 
         return data({ sessionDetailsSaved: true })
+    }
+
+    // Session-level, not speaker-level — a dual-speaker session only needs
+    // one presenter to accept it. Handled before the targetSessionizeId
+    // guard below, since this form submits sessionizeSessionId(s) instead.
+    // No ownership check needed — an admin is already fully trusted.
+    if (actionType === 'accept-backup') {
+        const sessionIds = formData.getAll('sessionizeSessionId').filter((v): v is string => typeof v === 'string')
+        for (const id of sessionIds) {
+            await services.speakers.markBackupAccepted(id, email)
+        }
+        return data({ backupAccepted: true })
     }
 
     const targetSessionizeId = formData.get('targetSessionizeId')
@@ -130,7 +145,13 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
 
     if (actionType === 'save-meet-the-experts') {
-        await services.speakers.saveMeetTheExpertsSlots(targetSessionizeId, parseMeetTheExpertsForm(formData), email)
+        const { slots, bioUseSessionizeBio, bioCustomText } = parseMeetTheExpertsForm(formData)
+        await services.meetTheExperts.saveRegistration(
+            'speaker',
+            targetSessionizeId,
+            { slots, bioUseDefault: bioUseSessionizeBio, bioCustomText },
+            email,
+        )
         return data({ meetTheExpertsSaved: true })
     }
 
@@ -173,6 +194,7 @@ export default function AdminSpeakerPreview() {
                 sessionizeId={view.sessionizeId}
                 checklist={view.checklist}
                 ticketClaimUrl={view.ticketClaimUrl}
+                backupSessionIds={view.backupSessionIds}
                 onOpenModal={setOpenModal}
                 alwaysEditable
             />

--- a/core/website/app/routes/admin.speakers._index.tsx
+++ b/core/website/app/routes/admin.speakers._index.tsx
@@ -1,16 +1,18 @@
 import { conferenceManifest } from '@conference/manifest'
 import { DateTime } from 'luxon'
-import { data, Form, useActionData, useLoaderData, useNavigation } from 'react-router'
+import { useEffect, useState } from 'react'
+import { data, Form, useActionData, useFetcher, useLoaderData, useNavigation } from 'react-router'
 import { AdminCard } from '~/components/admin-card'
 import { AdminLayout } from '~/components/admin-layout'
 import { AppLink } from '~/components/app-link'
+import { SpeakerModal } from '~/components/speaker-modal'
 import { Button } from '~/components/ui/button'
 import { requireAdmin } from '~/lib/auth.server'
 import { formatRelativeTime } from '~/lib/format-relative-time'
 import { recordException } from '~/lib/record-exception'
 import { dueDateRemainingLabel, urgencyFor, type ChecklistUrgency } from '~/lib/speakers/checklist'
 import { SPEAKER_CHECKLIST_ITEMS, type ChecklistItemDefinition } from '~/lib/speakers/checklist-items'
-import { computeContactImportPlan, parseSpeakerContactsCsv } from '~/lib/speakers/contact-import'
+import { computeContactImportPlan, parseSpeakerContactsCsv, parseSpeakerContactsExcel } from '~/lib/speakers/contact-import'
 import { speakersMissingChecklistItem } from '~/lib/speakers/follow-up'
 import { FOLLOW_UP_EMAIL_TEMPLATES } from '~/lib/speakers/follow-up-emails'
 import { buildRsvpHeadcount, type RsvpHeadcount } from '~/lib/speakers/rsvp-summary'
@@ -23,6 +25,10 @@ interface SessionTableRow {
     title: string
     hasSlot: boolean
     isConfirmed: boolean
+    /** Self-reported "I accept being a backup speaker" — session-level
+     * (shared by every presenter, so only one of them needs to accept), only
+     * relevant for a waitlisted session but populated regardless of status. */
+    backupAccepted: boolean
     presenters: Array<{
         sessionizeId: string
         fullName: string
@@ -65,6 +71,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
             syncAvailable: false,
             rsvpHeadcount: null,
             followUps: [],
+            speakerEmailAddress: undefined,
         })
     }
 
@@ -81,7 +88,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     // means they're genuinely out — no need to keep showing them here.
     // Grouped by session rather than by speaker so co-presenters share one
     // row, and split by status rather than showing it inline per row.
-    const sessionsById = new Map<string, SessionTableRow & { status: string }>()
+    const sessionsById = new Map<string, SessionTableRow & { status: string; foundInSessionize: boolean }>()
     for (const speaker of speakers.filter((s) => s.active)) {
         for (const session of speaker.sessions) {
             let row = sessionsById.get(session.sessionizeSessionId)
@@ -92,6 +99,8 @@ export async function loader({ request, context }: Route.LoaderArgs) {
                     status: session.status,
                     hasSlot: Boolean(session.startsAt),
                     isConfirmed: session.isConfirmed,
+                    backupAccepted: speaker.sessionBackupAccepted[session.sessionizeSessionId] ?? false,
+                    foundInSessionize: session.foundInSessionize,
                     presenters: [],
                 }
                 sessionsById.set(session.sessionizeSessionId, row)
@@ -132,16 +141,21 @@ export async function loader({ request, context }: Route.LoaderArgs) {
         configured: true as const,
         year: portalConfig.year,
         acceptedSessions: allSessions.filter((s) => s.status === 'Accepted'),
-        waitlistedSessions: allSessions.filter((s) => s.status !== 'Accepted'),
+        // A waitlisted session id Sessionize no longer lists at all (as
+        // opposed to one that's just not synced yet) most likely means it's
+        // been declined/withdrawn since — nothing useful to show an admin,
+        // so drop it instead of a row of raw ids.
+        waitlistedSessions: allSessions.filter((s) => s.status !== 'Accepted' && s.foundInSessionize),
         lastRun,
         syncAvailable: services.speakerSync.isConfigured(),
         rsvpHeadcount,
         followUps,
+        speakerEmailAddress: portalConfig.speakerEmailAddress,
     })
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
-    await requireAdmin(request, context)
+    const { email } = await requireAdmin(request, context)
     const services = getServices(context)
 
     const formData = await request.formData()
@@ -170,15 +184,19 @@ export async function action({ request, context }: Route.ActionArgs) {
 
         const file = formData.get('csv')
         if (!(file instanceof File) || file.size === 0) {
-            return data({ _action: actionName, error: 'Choose a CSV file to upload' }, { status: 400 })
+            return data({ _action: actionName, error: 'Choose a CSV or Excel file to upload' }, { status: 400 })
         }
+
+        const isExcel = /\.xlsx?$/i.test(file.name) || EXCEL_MIME_TYPES.has(file.type)
 
         let rows
         try {
-            rows = parseSpeakerContactsCsv(await file.text())
+            rows = isExcel
+                ? parseSpeakerContactsExcel(await file.arrayBuffer())
+                : parseSpeakerContactsCsv(await file.text())
         } catch (error) {
             return data(
-                { _action: actionName, error: error instanceof Error ? error.message : 'Could not parse CSV' },
+                { _action: actionName, error: error instanceof Error ? error.message : 'Could not parse file' },
                 { status: 400 },
             )
         }
@@ -200,25 +218,27 @@ export async function action({ request, context }: Route.ActionArgs) {
         return data({ _action: actionName, imported: plan.rows })
     }
 
+    if (actionName === 'accept-backup') {
+        const sessionizeSessionId = formData.get('sessionizeSessionId')
+        if (typeof sessionizeSessionId !== 'string' || !sessionizeSessionId) {
+            return data({ _action: actionName, error: 'Missing session' }, { status: 400 })
+        }
+        await services.speakers.markBackupAccepted(sessionizeSessionId, email)
+        return data({ _action: actionName, sessionizeSessionId })
+    }
+
     if (actionName === 'follow-up') {
         const portalConfig = conferenceManifest.speakerPortal
         if (!portalConfig) {
             return data({ _action: actionName, error: 'Speaker portal not configured' }, { status: 400 })
         }
 
-        const itemKey = formData.get('itemKey')
-        const definition = SPEAKER_CHECKLIST_ITEMS.find(
-            (d): d is ChecklistItemDefinition => d.key === itemKey,
-        )
+        const definition = requireChecklistDefinition(formData.get('itemKey'))
         if (!definition) {
             return data({ _action: actionName, error: 'Unknown checklist item' }, { status: 400 })
         }
 
-        const speakers = await services.speakers.listSpeakers(portalConfig.year)
-        const now = getDateTimeProvider(context).nowDate()
-        const targets = speakersMissingChecklistItem(speakers, definition.key, now)
-        const portalUrl = new URL('/speaker-portal', getConfig(context).webUrl).toString()
-        const conferenceName = conferenceManifest.public.name
+        const { targets, portalUrl, conferenceName } = await loadFollowUpTargets(services, context, portalConfig, definition.key)
         const template = FOLLOW_UP_EMAIL_TEMPLATES[definition.key]
 
         let emailsSent = 0
@@ -228,6 +248,7 @@ export async function action({ request, context }: Route.ActionArgs) {
                 try {
                     await services.email.send({
                         to: email,
+                        replyTo: portalConfig.speakerEmailAddress,
                         subject: template.subject,
                         text: template.text(vars),
                         html: template.html(vars),
@@ -244,8 +265,103 @@ export async function action({ request, context }: Route.ActionArgs) {
         return data({ _action: actionName, itemKey: definition.key, speakersCount: targets.length, emailsSent })
     }
 
+    if (actionName === 'follow-up-test') {
+        const portalConfig = conferenceManifest.speakerPortal
+        if (!portalConfig) {
+            return data({ _action: actionName, error: 'Speaker portal not configured' }, { status: 400 })
+        }
+
+        const speakerEmailAddress = portalConfig.speakerEmailAddress
+        if (!speakerEmailAddress) {
+            return data({ _action: actionName, error: 'No speaker email address configured for this conference' }, { status: 400 })
+        }
+
+        const definition = requireChecklistDefinition(formData.get('itemKey'))
+        if (!definition) {
+            return data({ _action: actionName, error: 'Unknown checklist item' }, { status: 400 })
+        }
+
+        const { targets, portalUrl, conferenceName } = await loadFollowUpTargets(services, context, portalConfig, definition.key)
+        const template = FOLLOW_UP_EMAIL_TEMPLATES[definition.key]
+        const vars = { firstName: 'there', portalUrl, conferenceName }
+        const recipientEmails = targets.flatMap((target) => target.contacts)
+
+        // The real send only ever goes to `speakerEmailAddress` — this list is
+        // logged so an admin can sanity-check who a live send would reach
+        // without actually emailing any of them.
+        console.log(
+            `[follow-up test email] ${definition.label}: would send to ${recipientEmails.length} address(es): ${recipientEmails.join(', ') || '(none)'}`,
+        )
+
+        await services.email.send({
+            to: speakerEmailAddress,
+            replyTo: speakerEmailAddress,
+            subject: template.subject,
+            text: template.text(vars),
+            html: template.html(vars),
+        })
+
+        return data({
+            _action: actionName,
+            itemKey: definition.key,
+            speakerEmailAddress,
+            recipientCount: recipientEmails.length,
+        })
+    }
+
+    if (actionName === 'follow-up-manual') {
+        const portalConfig = conferenceManifest.speakerPortal
+        if (!portalConfig) {
+            return data({ _action: actionName, error: 'Speaker portal not configured' }, { status: 400 })
+        }
+
+        const definition = requireChecklistDefinition(formData.get('itemKey'))
+        if (!definition) {
+            return data({ _action: actionName, error: 'Unknown checklist item' }, { status: 400 })
+        }
+
+        const { targets, portalUrl, conferenceName } = await loadFollowUpTargets(services, context, portalConfig, definition.key)
+        const template = FOLLOW_UP_EMAIL_TEMPLATES[definition.key]
+        const vars = { firstName: 'there', portalUrl, conferenceName }
+        const recipientEmails = targets.flatMap((target) => target.contacts)
+
+        return data({
+            _action: actionName,
+            itemKey: definition.key,
+            subject: template.subject,
+            emailText: template.text(vars),
+            emailAddresses: recipientEmails.join(', '),
+        })
+    }
+
     return data({ _action: 'unknown' as const, error: 'Unknown action' }, { status: 400 })
 }
+
+function requireChecklistDefinition(itemKey: FormDataEntryValue | null): ChecklistItemDefinition | undefined {
+    return SPEAKER_CHECKLIST_ITEMS.find((d): d is ChecklistItemDefinition => d.key === itemKey)
+}
+
+/** Shared setup for all three follow-up actions (real send, test send,
+ * manual-copy preview) — the audience and template variables (other than
+ * `firstName`) never differ between them. */
+async function loadFollowUpTargets(
+    services: ReturnType<typeof getServices>,
+    context: Route.ActionArgs['context'],
+    portalConfig: NonNullable<typeof conferenceManifest.speakerPortal>,
+    itemKey: ChecklistItemDefinition['key'],
+) {
+    const speakers = await services.speakers.listSpeakers(portalConfig.year)
+    const now = getDateTimeProvider(context).nowDate()
+    const targets = speakersMissingChecklistItem(speakers, itemKey, now)
+    const portalUrl = new URL('/speaker-portal', getConfig(context).webUrl).toString()
+    const conferenceName = conferenceManifest.public.name
+    return { targets, portalUrl, conferenceName }
+}
+
+const EXCEL_MIME_TYPES = new Set([
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.ms-excel',
+])
 
 const IMPORT_STATUS_LABEL: Record<string, string> = {
     granted: '✅ Granted',
@@ -292,14 +408,20 @@ export default function AdminSpeakers() {
         )
     }
 
-    const { acceptedSessions, waitlistedSessions, lastRun, syncAvailable, year, rsvpHeadcount, followUps } = loaderData
+    const { acceptedSessions, waitlistedSessions, lastRun, syncAvailable, year, rsvpHeadcount, followUps, speakerEmailAddress } =
+        loaderData
 
     return (
         <AdminLayout heading={`Speakers (${year})`}>
             {rsvpHeadcount && <RsvpHeadcountCard headcount={rsvpHeadcount} />}
 
             {followUps.length > 0 && (
-                <FollowUpCard followUps={followUps} actionData={actionData} navigation={navigation} />
+                <FollowUpCard
+                    followUps={followUps}
+                    actionData={actionData}
+                    navigation={navigation}
+                    speakerEmailAddress={speakerEmailAddress}
+                />
             )}
 
             <AdminCard>
@@ -334,6 +456,16 @@ export default function AdminSpeakers() {
                         >
                             <a href="/admin/speakers/export">Export sessions + photos</a>
                         </Button>
+                        <Button
+                            asChild
+                            variant="outline"
+                            color="admin.900"
+                            borderColor="admin.400"
+                            bg="white"
+                            _hover={{ bg: 'admin.100' }}
+                        >
+                            <a href="/admin/speakers/experts">Meet the Experts seating</a>
+                        </Button>
                         <Form method="post">
                             <input type="hidden" name="_action" value="sync-now" />
                             <Button type="submit" disabled={isSyncing || !syncAvailable}>
@@ -363,17 +495,24 @@ export default function AdminSpeakers() {
 
             <AdminCard>
                 <styled.h2 fontSize="xl" fontWeight="semibold" mb="2">
-                    Import portal access from CSV
+                    Import portal access from CSV or Excel
                 </styled.h2>
                 <styled.p fontSize="sm" color="admin.600" mb="4">
-                    Upload Sessionize's "flattened accepted sessions" export to grant portal access in bulk. Only
-                    Speaker Id, Session Id and Email are used — everything else comes from the Sessionize sync above.
-                    Re-uploading the same file is safe; existing access is never removed.
+                    Upload Sessionize's "flattened accepted sessions" export (CSV or Excel, first sheet only) to
+                    grant portal access in bulk. Only Speaker Id, Session Id and Email are used — everything else
+                    comes from the Sessionize sync above. Re-uploading the same file is safe; existing access is
+                    never removed.
                 </styled.p>
                 <Form method="post" encType="multipart/form-data">
                     <input type="hidden" name="_action" value="import-contacts" />
                     <Flex gap="2" align="center" flexWrap="wrap">
-                        <styled.input type="file" name="csv" accept=".csv,text/csv" required fontSize="sm" />
+                        <styled.input
+                            type="file"
+                            name="csv"
+                            accept=".csv,text/csv,.xlsx,.xls,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
+                            required
+                            fontSize="sm"
+                        />
                         <Button type="submit" disabled={isImporting}>
                             {isImporting ? 'Importing…' : 'Import'}
                         </Button>
@@ -431,6 +570,8 @@ export default function AdminSpeakers() {
                 heading="Backup"
                 emptyMessage="No waitlisted sessions synced yet."
                 sessions={waitlistedSessions}
+                showBackupAccepted
+                navigation={navigation}
             />
         </AdminLayout>
     )
@@ -470,14 +611,23 @@ function StatTile({ label, value, muted }: { label: string; value: number; muted
     )
 }
 
-/** One button per checklist item — emails every active speaker who hasn't
- * completed it yet (see the `follow-up` action, which reuses
- * `speakersMissingChecklistItem`/`speakerChecklist` so this can never drift
- * from what the speaker's own dashboard considers done). */
+/** One row per checklist item, each with three actions:
+ * - "Follow up" emails every active speaker who hasn't completed it yet (see
+ *   the `follow-up` action, which reuses
+ *   `speakersMissingChecklistItem`/`speakerChecklist` so this can never
+ *   drift from what the speaker's own dashboard considers done).
+ * - "Send test email" (`follow-up-test`) sends the same template to a fixed
+ *   inbox instead of real speakers, so wording/rendering can be checked
+ *   before a real send — it also logs the real recipient list to the
+ *   console for a sanity check.
+ * - "Send manual email" (`follow-up-manual`) doesn't send anything; it
+ *   fetches the rendered text and recipient list so they can be copy/pasted
+ *   into an external mail client. */
 function FollowUpCard({
     followUps,
     actionData,
     navigation,
+    speakerEmailAddress,
 }: {
     followUps: Array<{
         key: string
@@ -489,6 +639,7 @@ function FollowUpCard({
     }>
     actionData: ReturnType<typeof useActionData<typeof action>>
     navigation: ReturnType<typeof useNavigation>
+    speakerEmailAddress: string | undefined
 }) {
     return (
         <AdminCard>
@@ -511,6 +662,18 @@ function FollowUpCard({
                         : "Nobody to email — either everyone's done, or nobody outstanding has a contact on file."}
                 </Box>
             )}
+            {actionData?._action === 'follow-up-test' && 'error' in actionData && (
+                <Box role="alert" mb="4" p="3" bg="status.danger.bg" borderRadius="md" fontSize="sm" color="status.danger.fg">
+                    {actionData.error}
+                </Box>
+            )}
+            {actionData?._action === 'follow-up-test' && 'speakerEmailAddress' in actionData && (
+                <Box role="status" mb="4" p="3" bg="status.success.bg" borderRadius="md" fontSize="sm" color="status.success.fg">
+                    Test email sent to {actionData.speakerEmailAddress}. A real send would reach{' '}
+                    {actionData.recipientCount} address{actionData.recipientCount === 1 ? '' : 'es'} — see the
+                    server console for the full list.
+                </Box>
+            )}
 
             <Flex direction="column" gap="2">
                 {followUps.map((item) => {
@@ -518,52 +681,192 @@ function FollowUpCard({
                         navigation.state === 'submitting' &&
                         navigation.formData?.get('_action') === 'follow-up' &&
                         navigation.formData?.get('itemKey') === item.key
+                    const isSendingTest =
+                        navigation.state === 'submitting' &&
+                        navigation.formData?.get('_action') === 'follow-up-test' &&
+                        navigation.formData?.get('itemKey') === item.key
                     return (
-                        <Form key={item.key} method="post">
-                            <input type="hidden" name="_action" value="follow-up" />
-                            <input type="hidden" name="itemKey" value={item.key} />
-                            <Flex
-                                justify="space-between"
-                                align="center"
-                                gap="3"
-                                p="3"
-                                bg="admin.100"
-                                borderRadius="md"
-                                flexWrap="wrap"
-                            >
-                                <Box>
-                                    <styled.span display="block" fontSize="sm" color="admin.900">
-                                        {item.label} — <styled.strong>{item.count}</styled.strong> outstanding
+                        <Flex
+                            key={item.key}
+                            justify="space-between"
+                            align="center"
+                            gap="3"
+                            p="3"
+                            bg="admin.100"
+                            borderRadius="md"
+                            flexWrap="wrap"
+                        >
+                            <Box>
+                                <styled.span display="block" fontSize="sm" color="admin.900">
+                                    {item.label} — <styled.strong>{item.count}</styled.strong> outstanding
+                                </styled.span>
+                                {dueDateLabel(item.dueDateIso) && (
+                                    <styled.span
+                                        display="block"
+                                        fontSize="xs"
+                                        fontWeight={item.urgency === 'normal' ? 'normal' : 'semibold'}
+                                        color={URGENCY_TEXT_COLOR[item.urgency]}
+                                    >
+                                        {dueDateLabel(item.dueDateIso)}
+                                        {item.remainingLabel ? ` — ${item.remainingLabel}` : ''}
                                     </styled.span>
-                                    {dueDateLabel(item.dueDateIso) && (
-                                        <styled.span
-                                            display="block"
-                                            fontSize="xs"
-                                            fontWeight={item.urgency === 'normal' ? 'normal' : 'semibold'}
-                                            color={URGENCY_TEXT_COLOR[item.urgency]}
+                                )}
+                            </Box>
+                            <Flex gap="2" flexWrap="wrap">
+                                <Form method="post">
+                                    <input type="hidden" name="_action" value="follow-up" />
+                                    <input type="hidden" name="itemKey" value={item.key} />
+                                    <Button
+                                        type="submit"
+                                        variant="outline"
+                                        color="admin.900"
+                                        borderColor="admin.400"
+                                        bg="white"
+                                        _hover={{ bg: 'admin.100' }}
+                                        disabled={item.count === 0 || isSubmittingThis}
+                                    >
+                                        {isSubmittingThis ? 'Sending…' : `Follow up`}
+                                    </Button>
+                                </Form>
+                                {speakerEmailAddress && (
+                                    <Form method="post">
+                                        <input type="hidden" name="_action" value="follow-up-test" />
+                                        <input type="hidden" name="itemKey" value={item.key} />
+                                        <Button
+                                            type="submit"
+                                            variant="outline"
+                                            color="admin.900"
+                                            borderColor="admin.400"
+                                            bg="white"
+                                            _hover={{ bg: 'admin.100' }}
+                                            disabled={isSendingTest}
+                                            title={`Sends to ${speakerEmailAddress}`}
                                         >
-                                            {dueDateLabel(item.dueDateIso)}
-                                            {item.remainingLabel ? ` — ${item.remainingLabel}` : ''}
-                                        </styled.span>
-                                    )}
-                                </Box>
-                                <Button
-                                    type="submit"
-                                    variant="outline"
-                                    color="admin.900"
-                                    borderColor="admin.400"
-                                    bg="white"
-                                    _hover={{ bg: 'admin.100' }}
-                                    disabled={item.count === 0 || isSubmittingThis}
-                                >
-                                    {isSubmittingThis ? 'Sending…' : `Follow up: ${item.label}`}
-                                </Button>
+                                            {isSendingTest ? 'Sending…' : 'Send test'}
+                                        </Button>
+                                    </Form>
+                                )}
+                                <ManualEmailButton itemKey={item.key} label={item.label} />
                             </Flex>
-                        </Form>
+                        </Flex>
                     )
                 })}
             </Flex>
         </AdminCard>
+    )
+}
+
+/** Fetches the rendered follow-up text + recipient list without sending
+ * anything (`follow-up-manual`), then shows both in read-only fields sized
+ * for a quick select-all/copy into an external mail client (Outlook, Gmail,
+ * etc. — wherever the admin actually sends manual follow-ups from). */
+function ManualEmailButton({ itemKey, label }: { itemKey: string; label: string }) {
+    const fetcher = useFetcher<typeof action>()
+    const [open, setOpen] = useState(false)
+    const isLoading = fetcher.state !== 'idle'
+    const result = fetcher.data
+
+    // This fetcher only ever submits `follow-up-manual` for this one item, so
+    // any response it receives is this button's own — open the modal as soon
+    // as it lands rather than requiring a second click.
+    useEffect(() => {
+        if (result) setOpen(true)
+    }, [result])
+
+    return (
+        <>
+            <fetcher.Form method="post">
+                <input type="hidden" name="_action" value="follow-up-manual" />
+                <input type="hidden" name="itemKey" value={itemKey} />
+                <Button
+                    type="submit"
+                    variant="outline"
+                    color="admin.900"
+                    borderColor="admin.400"
+                    bg="white"
+                    _hover={{ bg: 'admin.100' }}
+                    disabled={isLoading}
+                >
+                    {isLoading ? 'Preparing…' : 'Manual Email'}
+                </Button>
+            </fetcher.Form>
+
+            <SpeakerModal title={`Manual email — ${label}`} open={open && Boolean(result)} onOpenChange={setOpen}>
+                {result && 'error' in result && (
+                    <Box role="alert" mb="4" p="3" bg="status.danger.bg" borderRadius="md" fontSize="sm" color="status.danger.fg">
+                        {result.error}
+                    </Box>
+                )}
+                {result && 'emailText' in result && (
+                    <Flex direction="column" gap="4">
+                        <Box>
+                            <styled.label display="block" fontSize="sm" fontWeight="medium" color="admin.700" mb="1">
+                                Subject
+                            </styled.label>
+                            <styled.input
+                                readOnly
+                                value={result.subject}
+                                onFocus={(e) => e.currentTarget.select()}
+                                w="full"
+                                px="3"
+                                py="2"
+                                borderWidth="1px"
+                                borderStyle="solid"
+                                borderColor="admin.400"
+                                borderRadius="md"
+                                fontSize="sm"
+                                bg="admin.50"
+                                color="admin.900"
+                            />
+                        </Box>
+                        <Box>
+                            <styled.label display="block" fontSize="sm" fontWeight="medium" color="admin.700" mb="1">
+                                Email text
+                            </styled.label>
+                            <styled.textarea
+                                readOnly
+                                value={result.emailText}
+                                onFocus={(e) => e.currentTarget.select()}
+                                w="full"
+                                rows={10}
+                                px="3"
+                                py="2"
+                                borderWidth="1px"
+                                borderStyle="solid"
+                                borderColor="admin.400"
+                                borderRadius="md"
+                                fontSize="sm"
+                                bg="admin.50"
+                                color="admin.900"
+                                fontFamily="mono"
+                            />
+                        </Box>
+                        <Box>
+                            <styled.label display="block" fontSize="sm" fontWeight="medium" color="admin.700" mb="1">
+                                Recipients ({result.emailAddresses ? result.emailAddresses.split(', ').length : 0})
+                            </styled.label>
+                            <styled.textarea
+                                readOnly
+                                value={result.emailAddresses}
+                                onFocus={(e) => e.currentTarget.select()}
+                                w="full"
+                                rows={3}
+                                px="3"
+                                py="2"
+                                borderWidth="1px"
+                                borderStyle="solid"
+                                borderColor="admin.400"
+                                borderRadius="md"
+                                fontSize="sm"
+                                bg="admin.50"
+                                color="admin.900"
+                                fontFamily="mono"
+                            />
+                        </Box>
+                    </Flex>
+                )}
+            </SpeakerModal>
+        </>
     )
 }
 
@@ -620,10 +923,19 @@ function SessionsTable({
     heading,
     emptyMessage,
     sessions,
+    showBackupAccepted = false,
+    navigation,
 }: {
     heading: string
     emptyMessage: string
     sessions: SessionTableRow[]
+    /** Adds a "Backup accepted" indicator + quick self-report button next to
+     * the session title, so an admin doesn't have to open the per-speaker
+     * preview just to mark a waitlisted session as accepted. Session-level —
+     * one control per session, not per presenter, since a dual-speaker
+     * session only needs one presenter to accept it. */
+    showBackupAccepted?: boolean
+    navigation?: ReturnType<typeof useNavigation>
 }) {
     return (
         <AdminCard>
@@ -650,6 +962,10 @@ function SessionsTable({
                         <styled.tbody>
                             {sessions.map((session) => {
                                 const confirmed = session.presenters.some((p) => p.confirmed)
+                                const isSubmittingThis =
+                                    navigation?.state === 'submitting' &&
+                                    navigation.formData?.get('_action') === 'accept-backup' &&
+                                    navigation.formData?.get('sessionizeSessionId') === session.sessionizeSessionId
                                 return session.presenters.map((presenter, index) => (
                                     <styled.tr
                                         key={presenter.sessionizeId}
@@ -658,11 +974,42 @@ function SessionsTable({
                                     >
                                         {index === 0 && (
                                             <styled.td py="2" pr="4" rowSpan={session.presenters.length} verticalAlign="top">
-                                                {session.title}{' '}
-                                                <StatusIcon
-                                                    ok={confirmed}
-                                                    label={confirmed ? 'Session confirmed' : 'Session not yet confirmed'}
-                                                />
+                                                <Flex direction="column" align="flex-start" gap="1">
+                                                    <Box>
+                                                        {session.title}{' '}
+                                                        {!showBackupAccepted && (
+                                                            <StatusIcon
+                                                                ok={confirmed}
+                                                                label={confirmed ? 'Session confirmed' : 'Session not yet confirmed'}
+                                                            />
+                                                        )}
+                                                    </Box>
+                                                    {showBackupAccepted &&
+                                                        (session.backupAccepted ? (
+                                                            <StatusIcon ok label="Backup speaker accepted" />
+                                                        ) : (
+                                                            <Form method="post">
+                                                                <input type="hidden" name="_action" value="accept-backup" />
+                                                                <input
+                                                                    type="hidden"
+                                                                    name="sessionizeSessionId"
+                                                                    value={session.sessionizeSessionId}
+                                                                />
+                                                                <Button
+                                                                    type="submit"
+                                                                    size="sm"
+                                                                    variant="outline"
+                                                                    color="admin.900"
+                                                                    borderColor="admin.400"
+                                                                    bg="white"
+                                                                    _hover={{ bg: 'admin.100' }}
+                                                                    disabled={isSubmittingThis}
+                                                                >
+                                                                    {isSubmittingThis ? 'Marking…' : 'Accept'}
+                                                                </Button>
+                                                            </Form>
+                                                        ))}
+                                                </Flex>
                                             </styled.td>
                                         )}
                                         <styled.td py="2" pr="4">

--- a/core/website/app/routes/admin.speakers.experts.tsx
+++ b/core/website/app/routes/admin.speakers.experts.tsx
@@ -1,0 +1,205 @@
+import { conferenceManifest } from '@conference/manifest'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { data, useLoaderData, useRevalidator } from 'react-router'
+import { AdminCard } from '~/components/admin-card'
+import { AdminLayout } from '~/components/admin-layout'
+import { MeetTheExpertsPlanner, type MeetTheExpertsChange } from '~/components/meet-the-experts-planner'
+import { requireAdmin } from '~/lib/auth.server'
+import { getServices } from '~/remix-app-load-context'
+import { Box, styled } from '~/styled-system/jsx'
+import type { Route } from './+types/admin.speakers.experts'
+
+export async function loader({ request, context }: Route.LoaderArgs) {
+    await requireAdmin(request, context)
+    const services = getServices(context)
+
+    const slots = conferenceManifest.meetTheExperts?.slots ?? []
+    const speakerYear = conferenceManifest.speakerPortal?.year
+    const sponsorYear = conferenceManifest.sponsorPortal?.year
+
+    const [speakers, sponsors, registrations, schedulingState] = await Promise.all([
+        speakerYear ? services.speakers.listSpeakers(speakerYear) : Promise.resolve([]),
+        sponsorYear ? services.sponsors.listSponsors(sponsorYear) : Promise.resolve([]),
+        services.meetTheExperts.listRegistrations(),
+        services.meetTheExpertsScheduling.getState(),
+    ])
+
+    const displayNameByKey = new Map<string, string>()
+    for (const speaker of speakers) displayNameByKey.set(`speaker:${speaker.sessionizeId}`, speaker.fullName)
+    for (const sponsor of sponsors) displayNameByKey.set(`sponsor:${sponsor.issueKey}`, sponsor.companyName)
+
+    const assignedCountByRegistrant = new Map<string, number>()
+    for (const assignment of schedulingState.assignments) {
+        const key = `${assignment.registrantType}:${assignment.registrantId}`
+        assignedCountByRegistrant.set(key, (assignedCountByRegistrant.get(key) ?? 0) + 1)
+    }
+
+    const registrants = registrations
+        .filter((registration) => registration.slots.length > 0)
+        .map((registration) => {
+            const key = `${registration.registrantType}:${registration.registrantId}`
+            return {
+                registrantType: registration.registrantType,
+                registrantId: registration.registrantId,
+                displayName: displayNameByKey.get(key) ?? registration.registrantId,
+                slots: registration.slots,
+                assignedCount: assignedCountByRegistrant.get(key) ?? 0,
+            }
+        })
+        .sort((a, b) => a.displayName.localeCompare(b.displayName))
+
+    const assignments = schedulingState.assignments.map((assignment) => ({
+        ...assignment,
+        displayName:
+            displayNameByKey.get(`${assignment.registrantType}:${assignment.registrantId}`) ??
+            assignment.registrantId,
+    }))
+
+    // Registered but said none of the configured slots work for them —
+    // a deliberate, complete answer, so they're excluded from the draggable
+    // pool rather than shown unschedulable.
+    const optedOutCount = registrations.filter((registration) => registration.slots.length === 0).length
+
+    return data({
+        slots,
+        tables: schedulingState.tables,
+        assignments,
+        registrants,
+        optedOutCount,
+    })
+}
+
+export async function action({ request, context }: Route.ActionArgs) {
+    const { email } = await requireAdmin(request, context)
+    const services = getServices(context)
+
+    const formData = await request.formData()
+    const str = (key: string) => {
+        const value = formData.get(key)
+        return typeof value === 'string' ? value : ''
+    }
+    const intent = str('intent')
+
+    try {
+        switch (intent) {
+            case 'add_table':
+                await services.meetTheExpertsScheduling.addTable(str('label') || 'New table')
+                break
+
+            case 'rename_table':
+                await services.meetTheExpertsScheduling.renameTable(str('tableId'), str('label'))
+                break
+
+            case 'remove_table':
+                await services.meetTheExpertsScheduling.removeTable(str('tableId'))
+                break
+
+            case 'move_table':
+                await services.meetTheExpertsScheduling.moveTable(
+                    str('tableId'),
+                    str('direction') === 'up' ? 'up' : 'down',
+                )
+                break
+
+            case 'assign': {
+                const registrantType = str('registrantType')
+                if (registrantType !== 'speaker' && registrantType !== 'sponsor') {
+                    return { success: false as const, error: `Unknown registrant type: ${registrantType}` }
+                }
+                await services.meetTheExpertsScheduling.assign(
+                    str('tableId'),
+                    str('slotId'),
+                    { type: registrantType, id: str('registrantId') },
+                    email,
+                )
+                break
+            }
+
+            case 'unassign':
+                await services.meetTheExpertsScheduling.unassign(str('tableId'), str('slotId'))
+                break
+
+            default:
+                return { success: false as const, error: `Unknown intent: ${intent}` }
+        }
+
+        return { success: true as const }
+    } catch (error: any) {
+        console.error('Meet the Experts scheduling action failed:', error)
+        return { success: false as const, error: error?.message ?? 'Failed to save' }
+    }
+}
+
+export default function AdminSpeakersExperts() {
+    const { slots, tables, assignments, registrants, optedOutCount } = useLoaderData<typeof loader>()
+    const revalidator = useRevalidator()
+
+    // Same queued-fetch-then-revalidate pattern as the agenda planner
+    // (admin.voting_.agenda.$runId.tsx): a fetcher would abort an in-flight
+    // submit when a second drag lands close behind it, so writes are chained
+    // through a manual promise queue instead.
+    const queue = useRef<Promise<unknown>>(Promise.resolve())
+    const [inFlight, setInFlight] = useState(0)
+    const [saveError, setSaveError] = useState<string | null>(null)
+
+    const save = useCallback((change: MeetTheExpertsChange) => {
+        setInFlight((n) => n + 1)
+        queue.current = queue.current
+            .then(async () => {
+                const response = await fetch(window.location.pathname, {
+                    method: 'POST',
+                    body: new URLSearchParams(change),
+                })
+                if (!response.ok) {
+                    throw new Error(`Save failed (${response.status})`)
+                }
+                const result: { success: boolean; error?: string } = await response.json()
+                if (!result.success) {
+                    throw new Error(result.error ?? 'Save failed')
+                }
+                setSaveError(null)
+            })
+            .catch((error: unknown) => {
+                console.error('Failed to save Meet the Experts scheduling:', error)
+                setSaveError(error instanceof Error ? error.message : 'Failed to save')
+            })
+            .finally(() => setInFlight((n) => n - 1))
+    }, [])
+
+    const isSaving = inFlight > 0
+
+    useEffect(() => {
+        if (!isSaving && revalidator.state === 'idle') {
+            void revalidator.revalidate()
+        }
+    }, [isSaving, revalidator])
+
+    return (
+        <AdminLayout heading="Meet the Experts — seating" fullWidth>
+            {optedOutCount > 0 && (
+                <AdminCard>
+                    <styled.p fontSize="sm" color="admin.700">
+                        {optedOutCount} {optedOutCount === 1 ? 'person has' : 'people have'} registered for Meet the
+                        Experts but said none of the slots work for them, so they aren't listed below.
+                    </styled.p>
+                </AdminCard>
+            )}
+
+            {saveError && (
+                <Box mb="4" p="3" bg="status.danger.bg" borderRadius="md" fontSize="sm" color="status.danger.fg">
+                    {saveError}
+                </Box>
+            )}
+
+            <AdminCard>
+                <MeetTheExpertsPlanner
+                    slots={slots}
+                    tables={tables}
+                    assignments={assignments}
+                    registrants={registrants}
+                    onChange={save}
+                />
+            </AdminCard>
+        </AdminLayout>
+    )
+}

--- a/core/website/app/routes/portal._index.tsx
+++ b/core/website/app/routes/portal._index.tsx
@@ -1,7 +1,11 @@
-import { useLoaderData } from 'react-router'
+import { useState } from 'react'
+import { conferenceManifest } from '@conference/manifest'
+import { data, useActionData, useLoaderData } from 'react-router'
 import { AdminCard } from '~/components/admin-card'
 import { AppLink } from '~/components/app-link'
+import { SponsorMeetTheExpertsModal } from '~/components/sponsor-meet-the-experts-modal'
 import { requireSponsorContact } from '~/lib/auth.server'
+import { parseMeetTheExpertsForm } from '~/lib/speakers/profile-form.server'
 import { isProfileComplete, profileChecklist } from '~/lib/sponsors/profile'
 import { getServices } from '~/remix-app-load-context'
 import { Box, Flex, styled } from '~/styled-system/jsx'
@@ -11,21 +15,66 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     const { sponsor } = await requireSponsorContact(request, context)
     const services = getServices(context)
 
-    const [profile, contacts] = await Promise.all([
+    const [profile, contacts, meetTheExpertsRegistration] = await Promise.all([
         services.sponsors.getProfile(sponsor.issueKey),
         services.sponsors.getContactEmails(sponsor.issueKey),
+        services.meetTheExperts.getRegistration('sponsor', sponsor.issueKey),
     ])
 
     return {
+        issueKey: sponsor.issueKey,
         checklist: profileChecklist(profile),
         complete: isProfileComplete(profile),
         completedAt: profile?.completedAt ?? null,
         contacts,
+        meetTheExpertsSlots: conferenceManifest.meetTheExperts?.slots ?? [],
+        meetTheExpertsResponded: Boolean(meetTheExpertsRegistration),
+        meetTheExpertsSelectedSlotIds: meetTheExpertsRegistration?.slots ?? [],
+        meetTheExpertsBioUseDefault: meetTheExpertsRegistration?.bioUseDefault ?? true,
+        meetTheExpertsBioCustomText: meetTheExpertsRegistration?.bioCustomText,
+        blurb: profile?.blurb,
     }
 }
 
+export async function action({ request, context }: Route.ActionArgs) {
+    const { user, sponsor } = await requireSponsorContact(request, context)
+    const services = getServices(context)
+
+    const formData = await request.formData()
+    const actionType = formData.get('_action')
+
+    if (actionType === 'save-meet-the-experts') {
+        const targetIssueKey = formData.get('targetIssueKey')
+        if (targetIssueKey !== sponsor.issueKey) throw new Response('Not Found', { status: 404 })
+        const { slots, bioUseSessionizeBio, bioCustomText } = parseMeetTheExpertsForm(formData)
+        await services.meetTheExperts.saveRegistration(
+            'sponsor',
+            sponsor.issueKey,
+            { slots, bioUseDefault: bioUseSessionizeBio, bioCustomText },
+            user.email,
+        )
+        return data({ meetTheExpertsSaved: true })
+    }
+
+    return data({ error: 'Unknown action' }, { status: 400 })
+}
+
 export default function PortalDashboard() {
-    const { checklist, complete, contacts } = useLoaderData<typeof loader>()
+    const {
+        issueKey,
+        checklist,
+        complete,
+        contacts,
+        meetTheExpertsSlots,
+        meetTheExpertsResponded,
+        meetTheExpertsSelectedSlotIds,
+        meetTheExpertsBioUseDefault,
+        meetTheExpertsBioCustomText,
+        blurb,
+    } = useLoaderData<typeof loader>()
+    const actionData = useActionData<typeof action>()
+    const [meetTheExpertsOpen, setMeetTheExpertsOpen] = useState(false)
+    const meetTheExpertsJustResponded = Boolean(actionData && 'meetTheExpertsSaved' in actionData)
 
     return (
         <Box maxW="4xl" mx="auto">
@@ -81,6 +130,43 @@ export default function PortalDashboard() {
                 </Flex>
             </AdminCard>
 
+            {meetTheExpertsSlots.length > 0 && (
+                <AdminCard>
+                    <styled.h2 fontSize="xl" fontWeight="semibold" mb="2">
+                        Meet the Experts
+                    </styled.h2>
+                    <styled.p fontSize="sm" color="admin.600" mb="4">
+                        Put someone from your team forward to chat with attendees during a Meet the Experts time
+                        slot.
+                    </styled.p>
+                    <Flex align="center" justify="space-between" gap="4" flexWrap="wrap">
+                        <styled.span fontSize="sm" color="admin.900">
+                            {meetTheExpertsResponded
+                                ? meetTheExpertsSelectedSlotIds.length > 0
+                                    ? `Registered for ${meetTheExpertsSelectedSlotIds.length} time slot${meetTheExpertsSelectedSlotIds.length === 1 ? '' : 's'}.`
+                                    : "Registered — you've said none of the slots work."
+                                : 'Not yet registered.'}
+                        </styled.span>
+                        <styled.button
+                            type="button"
+                            onClick={() => setMeetTheExpertsOpen(true)}
+                            bg="admin.900"
+                            color="white"
+                            border="none"
+                            py="2"
+                            px="4"
+                            borderRadius="md"
+                            fontSize="sm"
+                            fontWeight="semibold"
+                            cursor="pointer"
+                            _hover={{ bg: 'admin.800' }}
+                        >
+                            {meetTheExpertsResponded ? 'Update' : 'Register'}
+                        </styled.button>
+                    </Flex>
+                </AdminCard>
+            )}
+
             <AdminCard>
                 <styled.h2 fontSize="xl" fontWeight="semibold" mb="2">
                     Who can access this workspace
@@ -97,6 +183,19 @@ export default function PortalDashboard() {
                     ))}
                 </Flex>
             </AdminCard>
+
+            <SponsorMeetTheExpertsModal
+                open={meetTheExpertsOpen}
+                onOpenChange={setMeetTheExpertsOpen}
+                issueKey={issueKey}
+                slots={meetTheExpertsSlots}
+                selectedSlotIds={meetTheExpertsSelectedSlotIds}
+                hasResponded={meetTheExpertsResponded}
+                justResponded={meetTheExpertsJustResponded}
+                blurb={blurb}
+                bioUseDefault={meetTheExpertsBioUseDefault}
+                bioCustomText={meetTheExpertsBioCustomText}
+            />
         </Box>
     )
 }

--- a/core/website/app/routes/speaker-portal._index.tsx
+++ b/core/website/app/routes/speaker-portal._index.tsx
@@ -21,12 +21,15 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     const { speaker } = await requireSpeaker(request, context)
     const services = getServices(context)
 
-    const workspace = await services.speakers.getWorkspace(speaker.sessionizeId)
+    const [workspace, meetTheExpertsRegistration] = await Promise.all([
+        services.speakers.getWorkspace(speaker.sessionizeId),
+        services.meetTheExperts.getRegistration('speaker', speaker.sessionizeId),
+    ])
     if (!workspace) {
         throw new Response('Not Found', { status: 404 })
     }
 
-    return buildSpeakerDashboardView(context, workspace, speaker.sessionizeId)
+    return buildSpeakerDashboardView(context, workspace, speaker.sessionizeId, meetTheExpertsRegistration)
 }
 
 function oneOf<T extends string>(value: FormDataEntryValue | null, options: readonly T[]): T | undefined {
@@ -76,6 +79,21 @@ export async function action({ request, context }: Route.ActionArgs) {
         }
 
         return data({ sessionDetailsSaved: true })
+    }
+
+    // Session-level, not speaker-level — a dual-speaker session only needs
+    // one presenter to accept it. Handled before the targetSessionizeId
+    // guard below, since this form submits sessionizeSessionId(s) instead.
+    if (actionType === 'accept-backup') {
+        const sessionIds = formData.getAll('sessionizeSessionId').filter((v): v is string => typeof v === 'string')
+        for (const id of sessionIds) {
+            const onSession = await services.speakers.isSpeakerOnSession(speaker.sessionizeId, id)
+            if (!onSession) throw new Response('Not Found', { status: 404 })
+        }
+        for (const id of sessionIds) {
+            await services.speakers.markBackupAccepted(id, user.email)
+        }
+        return data({ backupAccepted: true })
     }
 
     const targetSessionizeId = formData.get('targetSessionizeId')
@@ -134,7 +152,13 @@ export async function action({ request, context }: Route.ActionArgs) {
 
     if (actionType === 'save-meet-the-experts') {
         if (targetSessionizeId !== speaker.sessionizeId) throw new Response('Not Found', { status: 404 })
-        await services.speakers.saveMeetTheExpertsSlots(speaker.sessionizeId, parseMeetTheExpertsForm(formData), user.email)
+        const { slots, bioUseSessionizeBio, bioCustomText } = parseMeetTheExpertsForm(formData)
+        await services.meetTheExperts.saveRegistration(
+            'speaker',
+            speaker.sessionizeId,
+            { slots, bioUseDefault: bioUseSessionizeBio, bioCustomText },
+            user.email,
+        )
         return data({ meetTheExpertsSaved: true })
     }
 
@@ -167,6 +191,7 @@ export default function SpeakerPortalDashboard() {
                 sessionizeId={view.sessionizeId}
                 checklist={view.checklist}
                 ticketClaimUrl={view.ticketClaimUrl}
+                backupSessionIds={view.backupSessionIds}
                 onOpenModal={setOpenModal}
             />
 

--- a/core/website/migrations/0016_speaker_backup_accepted.sql
+++ b/core/website/migrations/0016_speaker_backup_accepted.sql
@@ -1,0 +1,13 @@
+-- Speaker portal: backup speaker acceptance is a session-level self-report
+--
+-- A waitlisted (backup) session has no "confirm in Sessionize" step, so
+-- speakers instead self-report accepting the backup slot from the
+-- checklist. Session-level and shared by every presenter — same idiom as
+-- session_details — so a dual-speaker session only needs one presenter to
+-- accept it, not each of them individually.
+
+CREATE TABLE session_backup_acceptance (
+    sessionize_session_id TEXT PRIMARY KEY,
+    accepted_at INTEGER NOT NULL,
+    accepted_by TEXT NOT NULL
+);

--- a/core/website/migrations/0017_meet_the_experts_registrations.sql
+++ b/core/website/migrations/0017_meet_the_experts_registrations.sql
@@ -1,0 +1,36 @@
+-- Meet the Experts: shared table for speaker + sponsor registrations
+--
+-- Meet-the-Experts slot/bio registration used to live entirely on
+-- speaker_profiles. Sponsors can now register too, so it moves into its own
+-- table keyed by (registrant_type, registrant_id) — sessionize_id for a
+-- speaker, issue_key for a sponsor. The speaker-only opt-in question
+-- (register_meet_the_experts / _other, asked on the main session-details
+-- form) stays on speaker_profiles untouched.
+--
+-- The portal is live, so this backfills existing speaker registrations
+-- before dropping the old columns rather than dropping them outright.
+
+CREATE TABLE IF NOT EXISTS meet_the_experts_registrations (
+    registrant_type TEXT NOT NULL CHECK (registrant_type IN ('speaker', 'sponsor')),
+    registrant_id TEXT NOT NULL,
+    slots_json TEXT,
+    bio_use_default INTEGER NOT NULL DEFAULT 1,
+    bio_custom_text TEXT,
+    responded_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    updated_by TEXT NOT NULL,
+    PRIMARY KEY (registrant_type, registrant_id)
+);
+
+INSERT INTO meet_the_experts_registrations
+    (registrant_type, registrant_id, slots_json, bio_use_default, bio_custom_text, responded_at, updated_at, updated_by)
+SELECT 'speaker', sessionize_id, register_meet_the_experts_slots_json,
+       meet_the_experts_bio_use_sessionize_bio, meet_the_experts_bio_custom_text,
+       register_meet_the_experts_responded_at, updated_at, updated_by
+FROM speaker_profiles
+WHERE register_meet_the_experts_responded_at IS NOT NULL;
+
+ALTER TABLE speaker_profiles DROP COLUMN register_meet_the_experts_slots_json;
+ALTER TABLE speaker_profiles DROP COLUMN register_meet_the_experts_responded_at;
+ALTER TABLE speaker_profiles DROP COLUMN meet_the_experts_bio_use_sessionize_bio;
+ALTER TABLE speaker_profiles DROP COLUMN meet_the_experts_bio_custom_text;

--- a/core/website/migrations/0018_meet_the_experts_scheduling.sql
+++ b/core/website/migrations/0018_meet_the_experts_scheduling.sql
@@ -1,0 +1,30 @@
+-- Meet the Experts: table/timeslot scheduling
+--
+-- Registrants (speakers or sponsors) already record which configured time
+-- slots they're willing to do in meet_the_experts_registrations. This adds
+-- the admin-facing scheduling layer on top: a number of admin-created tables,
+-- and the assignment of a registrant to a (table, slot) cell. Slots
+-- themselves aren't a DB table — they're the same `meetTheExperts.slots`
+-- list from the conference manifest that registrants already picked from.
+
+CREATE TABLE IF NOT EXISTS meet_the_experts_tables (
+    id TEXT PRIMARY KEY,
+    label TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS meet_the_experts_assignments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    table_id TEXT NOT NULL REFERENCES meet_the_experts_tables(id) ON DELETE CASCADE,
+    slot_id TEXT NOT NULL,
+    registrant_type TEXT NOT NULL CHECK (registrant_type IN ('speaker', 'sponsor')),
+    registrant_id TEXT NOT NULL,
+    assigned_at INTEGER NOT NULL,
+    assigned_by TEXT NOT NULL,
+    -- At most one occupant per table per slot.
+    UNIQUE (table_id, slot_id),
+    -- A person can only be seated at one table for any given slot.
+    UNIQUE (slot_id, registrant_type, registrant_id)
+);

--- a/core/website/package.json
+++ b/core/website/package.json
@@ -36,6 +36,7 @@
         "tiny-invariant": "^1.3.3",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.1.0",
+        "xlsx": "^0.18.5",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
     },

--- a/core/website/safe-routes.d.ts
+++ b/core/website/safe-routes.d.ts
@@ -38,6 +38,10 @@ declare module "safe-routes" {
       params: {'sessionizeId': string | number},
       query: ExportedQuery<import('app/routes/admin.speakers.$sessionizeId.js').SearchParams>,
     },
+    "/admin/speakers/experts": {
+      params: never,
+      query: ExportedQuery<import('app/routes/admin.speakers.experts.js').SearchParams>,
+    },
     "/admin/speakers/export": {
       params: never,
       query: ExportedQuery<import('app/routes/admin.speakers.export.js').SearchParams>,
@@ -226,6 +230,7 @@ declare module "safe-routes" {
             | 'routes/admin.settings'
             | 'routes/admin.speakers'
             | 'routes/admin.speakers.$sessionizeId'
+            | 'routes/admin.speakers.experts'
             | 'routes/admin.speakers._index'
             | 'routes/admin.speakers.export'
             | 'routes/admin.sponsors'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -3504,6 +3507,10 @@ packages:
     resolution: {integrity: sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==}
     engines: {node: '>= 16.0.0'}
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -3795,6 +3802,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -3860,6 +3871,10 @@ packages:
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -3950,6 +3965,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4487,6 +4507,10 @@ packages:
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   framer-motion@12.43.0:
     resolution: {integrity: sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==}
@@ -6355,6 +6379,10 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -6905,9 +6933,17 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
 
   wordwrapjs@5.1.1:
     resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
@@ -6950,6 +6986,11 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-js@1.6.11:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
@@ -10848,6 +10889,8 @@ snapshots:
 
   address@2.0.3: {}
 
+  adler-32@1.3.1: {}
+
   agent-base@6.0.2(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
@@ -11171,6 +11214,11 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -11229,6 +11277,8 @@ snapshots:
   clone@1.0.4: {}
 
   code-block-writer@13.0.3: {}
+
+  codepage@1.15.0: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -11309,6 +11359,8 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
+
+  crc-32@1.2.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -11999,6 +12051,8 @@ snapshots:
       mime-types: 2.1.35
 
   format@0.2.2: {}
+
+  frac@1.1.2: {}
 
   framer-motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -14511,6 +14565,10 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stackback@0.0.2: {}
 
   standardwebhooks@1.0.0:
@@ -15173,7 +15231,11 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wmf@1.0.2: {}
+
   word-wrap@1.2.5: {}
+
+  word@0.3.0: {}
 
   wordwrapjs@5.1.1: {}
 
@@ -15217,6 +15279,16 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xml-js@1.6.11:
     dependencies:


### PR DESCRIPTION
## Summary
- Track session-level backup-speaker acceptance and surface it in the admin speakers view
- Support Excel (.xlsx) uploads for speaker contact import, alongside existing CSV
- Add a full Meet the Experts flow: sponsor booking modal, speaker scheduling planner, admin management route, and D1-backed stores/migrations

## Test plan
- [x] `nx typecheck website`
- [x] `nx lint website`
- [x] `nx test website` (291 tests passing)
- [x] Manual verification of Meet the Experts booking flow in a running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)